### PR TITLE
Academic Theme Footer Link Updated

### DIFF
--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -22,7 +22,7 @@
     {{ if not site.Params.i_am_a_sponsor }}
     This website is published using two great open source tools: 
     <a href="https://gohugo.io" target="_blank" rel="noopener">Hugo</a> & the
-    <a href="https://sourcethemes.com/academic/" target="_blank" rel="noopener">Academic theme.</a>
+    <a href="https://hugoblox.com/" target="_blank" rel="noopener">Academic theme.</a>
     {{ end }}
 
     {{ if not (in (slice "book" "docs" "updates") .Type) }}


### PR DESCRIPTION
Updated the link to the Academic theme to the recent site (https://hugoblox.com/)  the old one  was redirecting to a spam site (https://sourcethemes.com/academic/) 

The issue number  is #77 