### PR TITLE
Fix deprecated authors param

### DIFF
--- a/content/about/community/people.md
+++ b/content/about/community/people.md
@@ -14,11 +14,11 @@ subtitle = ""
   # Choose which groups/teams of users to display.
   #   Edit `user_groups` in each user's profile to add them to one or more of these groups.
   user_groups = [""
-#                 "Steering Committee",
- #                "Advisors",
-  #               "Principled Teachers and Mentors",
-   #              "FORRT Ambassadors",
-    #             "Code of Conduct Committee"
+ #              "Steering Committee",
+ #              "Advisors",
+ #              "Principled Teachers and Mentors",
+ #              "FORRT Ambassadors",
+ #              "Code of Conduct Committee"
     ]
 
 [design]

--- a/content/authors/forrt/_index.md
+++ b/content/authors/forrt/_index.md
@@ -20,7 +20,6 @@ email: "info@forrt.org"
 # - Artificial Intelligence
 # - Computational Linguistics
 # - Information Retrieval
-name: FORRT
 # organizations:
 # - name: Stanford University
 #   url: ""

--- a/content/talk/os-day-goethe/index.md
+++ b/content/talk/os-day-goethe/index.md
@@ -1,6 +1,5 @@
 ---
 title: FORRT presentation @ Open Science Day at Goethe University
-
 abstract: The Frankfurt Open Science Initiative organized an Open Science Day in Frankfurt at Goethe University whose theme revolved around Open Science and Teaching. FORRT was featured as one of the two main talks, and it was recorded.
 
 featured: true
@@ -46,4 +45,4 @@ FORRT was featured as one of the two main talks, and below you find the recordin
 
 For an overview of the whole event, see this [Twitter thead](https://twitter.com/OpenScienceFFM/status/1222523707870056450).
 
-{{< tweet 1222523707870056450 >}}
+{{< tweet user="OpenScienceFFM" id="1222523707870056450" >}}

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -1,0 +1,33 @@
+{{- define "main" -}}
+
+{{/* Author profile page. */}}
+
+{{/* If an account has not been created for this user, just display their name as the title. */}}
+{{ if not .File }}
+<div class="universal-wrapper pt-3">
+  <h1>{{ .Title }}</h1>
+</div>
+{{ end }}
+
+<section id="profile-page" class="pt-5">
+  <div class="container">
+    {{/* Show the About widget if an account exists for this user. */}}
+
+    {{ $query := where .Pages ".IsNode" false }}
+    {{ $count := len $query }}
+    {{ if $count }}
+    <div class="article-widget content-widget-hr">
+      <h3>{{ i18n "user_profile_latest" | default "Latest" }}</h3>
+      <ul>
+        {{ range $query }}
+        <li>
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </div>
+</section>
+
+{{- end -}}


### PR DESCRIPTION
This is a quick patch for the error
> ERROR Could not find an author page at `/authors/authors`. Please check the value of `author` in your About widget and create an associated author page if one does not already exist. See https://sourcethemes.com/academic/docs/page-builder/#about

This is caused by newer HUGO version that has authors as param being deprecated. (See https://github.com/gohugoio/hugo/issues/10551#issuecomment-1358107638 for a discussion).

There should be no undesirable effects as we are not using the authors/  list section page at all.

Thanks @flavioazevedo for help! 