### PR TITLE
Glossary's related page not working

### DIFF
--- a/layouts/glossary/single.html
+++ b/layouts/glossary/single.html
@@ -33,7 +33,7 @@
     {{end}}
 
 
-        {{ with .Params.related_terms }}
+<!--        {{ with .Params.related_terms }}
         {{ $term_urlized := "" }}
         <p class=" mb-1 pr-2"><strong>Related term{{- if gt (len .) 1 }}s{{- end -}}: </strong>
             {{ delimit (apply (apply (sort .) "partial" "glossary_link" ".") "chomp" ".") ", " }}
@@ -50,7 +50,23 @@
             {{- end -}}
             {{- end -}}  */}}
         </p>
-        {{- end -}}
+        {{- end -}}-->
+
+        {{ with .Params.related_terms }}
+          {{ $related_links := slice }}
+          {{ range $index, $term := . }}
+              {{ $term_urlized := urlize $term | truncate 35 }}
+              {{ $term_page := site.GetPage (printf "/glossary/%s" $term_urlized) }}
+              {{ if $term_page }}
+                  {{ $term_url := $term_page.RelPermalink }}
+                  {{ $related_links = $related_links | append (printf "<a href='%s'>%s</a>" $term_url $term) }}
+              {{ else }}
+                  {{ $related_links = $related_links | append $term }}
+              {{ end }}
+          {{ end }}
+          <p class="mb-1 pr-2"><strong>Related term{{ if gt (len $related_links) 1 }}s{{ end }}: </strong>{{ delimit $related_links ", " }}</p>
+        {{ end }}
+
 
         {{/*  Hacky way to display the var only if the len of the string with all objects is longer than 0   */}}
         {{ if .Params.alt_related_terms }}


### PR DESCRIPTION
I  used a loop to iterate through each related term.
Inside the loop, I calculate the URL for the term and check if a corresponding page exists.
If a page exists, I construct an anchor tag with the URL and term name and add it to the $related_links slice.
If a page doesn't exist, simply add the term name to the $related_links slice.
Finally, used delimit to concatenate the related term links with a comma separator.

Hopefully, it will handle and solve the error It is hard to say because both snippets of codes work on localhost 
just made this as an alternative to see if it could fix the bug As mentioned in the #96 issue

For testing i am not sure how i can achieve it since there is no preview based  on the  branch i guess unless merged 

@SamGuay and @flavioazevedo  would you  look into this ?