### PR TITLE
Hotfix: Checkout current branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Hugo - Setup

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: false
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Hugo - Setup


### PR DESCRIPTION
The default action for `actions/checkout@v4` is to checkout the default branch, and not the PR branch. We correct this by adding `${{ github.ref }}`. This correct behaviour that was intended by #111 