### PR TITLE
Updating Google Tag Manager script

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -279,5 +279,5 @@ plugins_js  = []
 ## Marketing
 ############################
 [marketing]
-  google_analytics = "G-GY39NFKC89"
-  google_tag_manager = "G-GY39NFKC89"
+  google_analytics = "G-2BTFVS6SPM"
+  google_tag_manager = "G-2BTFVS6SPM"

--- a/themes/academic/exampleSite/config/_default/params.toml
+++ b/themes/academic/exampleSite/config/_default/params.toml
@@ -273,8 +273,8 @@ plugins_js  = []
 ## Marketing
 ############################
 [marketing]
-  google_analytics = "G-GY39NFKC89"
-  google_tag_manager = "G-GY39NFKC89"
+  google_analytics = "G-2BTFVS6SPM"
+  google_tag_manager = "G-2BTFVS6SPM"
 
 ############################
 ## Content Management System

--- a/themes/academic/layouts/partials/marketing/google_tag_manager.html
+++ b/themes/academic/layouts/partials/marketing/google_tag_manager.html
@@ -1,9 +1,12 @@
 {{ if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") | and site.Params.marketing.google_tag_manager }}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.Params.marketing.google_tag_manager}}"></script>
 <script>
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{site.Params.marketing.google_tag_manager}}');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{site.Params.marketing.google_tag_manager}}');
 </script>
+
 {{ end }}


### PR DESCRIPTION
This is to update the Google Tag Manager script. This is part of the process to convert from Google Universal Analytics to Google Analytics 4. Created using the setup tool, as per the [Google analytics migration guide](https://support.google.com/analytics/answer/10759417).

This can't be tested until it's pushed to main because it needs to be embedded on the website and we don't have a testing sub-domain!