### PR TITLE
Add option to manually deploy to staging

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@ on:
       - master
   schedule:
   - cron: '0 0 * * *'  # Run daily at midnight
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
I just noted that the newsletter form was no longer visible in the staging area - with this change, we can stage any PR to check before approval.