### PR TITLE
Fix annotator URL

### DIFF
--- a/static/apps/fred_annotator.html
+++ b/static/apps/fred_annotator.html
@@ -17,6 +17,6 @@
       border: none;
   }
 </style>
-    <iframe src="/apps/fred_explorer.html"></iframe>
+    <iframe src="https://forrt-replications.shinyapps.io/fred_annotator/"></iframe>
 </body>
 </html>


### PR DESCRIPTION
Currently the FReD Annotator link leads to FReD Explorer - this fixes the link