### PR TITLE
Update tenzing.py (fixing issue with extra spaces on tenzing entries)

### DIFF
--- a/scripts/forrt_contribs/tenzing.py
+++ b/scripts/forrt_contribs/tenzing.py
@@ -91,7 +91,7 @@ merged_data['ORCID iD'] = merged_data['ORCID iD'].str.strip()
 # Function to format the full name
 def format_name(row):
     # Extract the first name, middle name initial, and surname
-    first_name = row['First name']].strip() if pd.notna(row['First name']) else ""
+    first_name = row['First name'].strip() if pd.notna(row['First name']) else ""
     middle_name = row['Middle name']
     surname = row['Surname'].strip() if pd.notna(row['Surname']) else ""
 

--- a/scripts/forrt_contribs/tenzing.py
+++ b/scripts/forrt_contribs/tenzing.py
@@ -93,7 +93,7 @@ def format_name(row):
     # Extract the first name, middle name initial, and surname
     first_name = row['First name']].strip() if pd.notna(row['First name']) else ""
     middle_name = row['Middle name']
-    surname = row['Surname']].strip() if pd.notna(row['First name']) else ""
+    surname = row['Surname'].strip() if pd.notna(row['Surname']) else ""
 
     # Check if the middle name is not NaN and not an empty string
     if pd.notna(middle_name) and middle_name != '':

--- a/scripts/forrt_contribs/tenzing.py
+++ b/scripts/forrt_contribs/tenzing.py
@@ -85,12 +85,15 @@ merged_data.reset_index(drop=True, inplace=True)
 
 merged_data = merged_data.sort_values(by='Surname')
 
+# Strip spaces from 'ORCID iD' in merged data
+merged_data['ORCID iD'] = merged_data['ORCID iD'].str.strip()
+
 # Function to format the full name
 def format_name(row):
     # Extract the first name, middle name initial, and surname
-    first_name = row['First name']
+    first_name = row['First name']].strip() if pd.notna(row['First name']) else ""
     middle_name = row['Middle name']
-    surname = row['Surname']
+    surname = row['Surname']].strip() if pd.notna(row['First name']) else ""
 
     # Check if the middle name is not NaN and not an empty string
     if pd.notna(middle_name) and middle_name != '':


### PR DESCRIPTION
This PR addresses an issue where inconsistencies in extra spaces in the ORCID iD and first name/surname column entries across Tenzing sheets caused duplicate entries for contributors on the FORRT website.

ORCID iD entries are now stripped of leading and trailing spaces. This happens after the desired columns are merged (which is prior to grouping by ORCID iD further down in the script).

The 'format_name' function now strips leading and trailing spaces from name fields before formatting the full name.

A test dataframe was used to check the changes in R Markdown, and they appeared to work, but my proposed changes should be reviewed bearing in mind that I have no idea what I'm doing with Python :)