### PR TITLE
Restore build action functionality for PRs from forks

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -89,6 +89,7 @@ jobs:
 
 
       - name: Download GA Data
+        if: ${{ github.event_name != 'pull_request' || secrets.GA_API_CREDENTIALS != '' }}
         env:
           GA_API_CREDENTIALS: ${{ secrets.GA_API_CREDENTIALS }}
           GA_PROPERTY_ID: ${{ secrets.GA_PROPERTY_ID }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -89,7 +89,7 @@ jobs:
 
 
       - name: Download GA Data
-        if: ${{ github.event_name != 'pull_request' || secrets.GA_API_CREDENTIALS != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.inputs.GA_API_CREDENTIALS != '' }}
         env:
           GA_API_CREDENTIALS: ${{ secrets.GA_API_CREDENTIALS }}
           GA_PROPERTY_ID: ${{ secrets.GA_PROPERTY_ID }}


### PR DESCRIPTION
Currently, the build action fails for any PR from forks, as the Google Analytics secrets are not available. This change skips the GA download step when the secret is not exposed to a PR.

@richarddushime can you pls check and merge if that makes sense to you? Until then, external contributions (Pauline, Emily) are stuck.