### PR TITLE
Change link color

### DIFF
--- a/data/themes/forrt.toml
+++ b/data/themes/forrt.toml
@@ -22,5 +22,5 @@ home_section_odd = "#fefdf6"
 home_section_even = "#fefdf6"
 background = "#fefdf6"
 
-link = "#004055"
+link = "#8e0000"
 link_hover = "#ff6bbc"


### PR DESCRIPTION
## Description

Change the link color to dark-red (as agreed with @flavioazevedo)

Fixes #127 

## Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- [x] Tested Locally
- [x] Checked in staging