### PR TITLE
Ensure staging.forrt.org has noindex

### DIFF
--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -25,6 +25,11 @@
   {{ $scr.Set "superuser_username" $superuser_username }}{{/* Set superuser globally for page_author.html. */}}
 
   {{ with $superuser_name }}<meta name="author" content="{{ . }}">{{ end }}
+  
+  {{/* Noindex for staging environment */}}
+  {{ if eq (getenv "HUGO_ENV") "staging" }}
+  <meta name="robots" content="noindex, nofollow">
+  {{ end }}
 
   {{/* Generate page description. */}}
   {{ $desc := "" }}

--- a/themes/academic/layouts/partials/site_head.html
+++ b/themes/academic/layouts/partials/site_head.html
@@ -23,6 +23,11 @@
 
   {{ with $superuser_name }}<meta name="author" content="{{ . }}">{{ end }}
 
+  {{/* Noindex for staging environment */}}
+  {{ if eq (getenv "HUGO_ENV") "staging" }}
+  <meta name="robots" content="noindex, nofollow">
+  {{ end }}
+
   {{/* Generate page description. */}}
   {{ $desc := "" }}
   {{ if .Params.summary }}

--- a/themes/academic/layouts/robots.txt
+++ b/themes/academic/layouts/robots.txt
@@ -1,0 +1,7 @@
+{{ if eq hugo.Environment "staging" }}
+User-agent: *
+Disallow: /
+{{ else }}
+User-agent: *
+Allow: /
+{{ end }}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include any relevant information where neccessary. -->
Do you have access to  Google Search results using Search Console?  for forrt.org ??  was staging.forrt.org also added ?? 
if yes you may need to check it and remove the existing indexes for staging only  

Otherwise lets  wait i will keep monitoring this and see if there is a change  but normally unindexing a domain on Google SEO it takes some time (approximate 2 weeks or less )

Fixes #284  (issue)

## Type of Change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration. -->

- [ ] Tested Locally
- [ ] Manual review / previewed on [staging.forrt.org](https://staging.forrt.org/)  content/webpage changes
- [ ] Not Tested yet

## Checklist for Content Editors and Non-Developers

<!-- This section applies to content, grammar and webpage updates changes: -->

- [ ] The content is clear, accurate, and follows community guidelines.
- [ ] All updated content has been previewed on the [staging site](https://staging.forrt.org/).
- [ ] All links, references, and formatting have been checked for correctness.
- [ ] The change aligns with the overall style and communication goals.
- [ ] No broken links in text/content

## Checklist for Developers:

- [ ] I have attempted to stay aligned to related code in this repository rather than reinventing the wheel.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Additional Notes
<!-- Add any other context or screenshots here -->
