### PR TITLE
Increase retention days from 1 to 7

### DIFF
--- a/.github/workflows/data-processing.yml
+++ b/.github/workflows/data-processing.yml
@@ -307,7 +307,7 @@ jobs:
             data/
             content/contributor-analysis/
             content/publications/citation_chart.webp
-          retention-days: 1
+          retention-days: 7
 
       #========================================
       # Commit generated files to build-resources branch


### PR DESCRIPTION
Currently, the data processing action output expires after 1 day - with the action now running only weakly, that leads to many independent data processing calls on PRs, so that this change increases efficiency and reduces load.