### PR TITLE
Fix navbar layout for iPad Pro and similar devices (1024px width)and preventing navbar cutoff while resizing the screen

### DIFF
--- a/assets/scss/academic/_nav.scss
+++ b/assets/scss/academic/_nav.scss
@@ -132,6 +132,184 @@
   color: $sta-menu-text;
 }
 
+/******************************************************************************
+ * Navbar Layout Fix for iPad Pro and Similar Devices (lg breakpoint)
+ * 
+ * 
+ * Solution: Optimize spacing, sizing, and layout only at lg breakpoint
+ *           (992px - 1199px) to fit all content without truncation.
+ * 
+ * Note: These styles ONLY apply at lg breakpoint. On xl+ screens (1200px+),
+ *       the navbar displays normally without these optimizations.
+ ******************************************************************************/
+@include media-breakpoint-only(lg) {
+  
+  /* ==========================================================================
+     Navbar Container Padding
+     ========================================================================== */
+  // Reduce horizontal padding on navbar to maximize available space
+  #navbar-main {
+    padding-left: 0.375rem !important;   // Reduced from default 1rem
+    padding-right: 0.375rem !important;
+  }
+
+  /* ==========================================================================
+     Navigation Items Spacing
+     ========================================================================== */
+  // Reduce padding on nav-items to create more horizontal space
+  // Override Bootstrap's px-2 class (0.5rem) with minimal padding
+  // Enable flex shrinking to allow items to compress when needed
+  #navbar-main .main-menu-item .nav-item {
+    padding-left: 0.1rem !important;   // Reduced from 0.5rem (px-2)
+    padding-right: 0.1rem !important;
+    flex-shrink: 1;                     // Allow items to shrink below content size
+    min-width: 0;                       // Override default min-width to allow compression
+  }
+
+  // Reduce padding on nav-links for tighter spacing between menu items
+  #navbar-main .main-menu-item .nav-item .nav-link {
+    padding-left: 0.2rem !important;
+    padding-right: 0.2rem !important;
+  }
+
+  // Reduce font size and letter spacing to fit more text in available space
+  #navbar-main .main-menu-item .nav-link {
+    font-size: calc(#{$sta-font-size-small}px - 3px);
+    letter-spacing: -0.015em;           // Tighter spacing for uppercase text
+  }
+
+  /* ==========================================================================
+     Navigation Icons Spacing
+     ========================================================================== */
+  // Reduce spacing on right-side nav icons (search, GitHub, etc.) to save space
+  ul.nav-icons {
+    padding-left: 0.2rem !important;
+    margin-left: 0 !important;
+    padding-top: 0.4rem !important;
+    padding-bottom: 0.4rem !important;
+  }
+  
+  ul.nav-icons li {
+    padding-right: 0.3rem !important;   // Reduced from default 1rem
+  }
+
+  /* ==========================================================================
+     "Get Involved" Button - Two-Line Layout
+     ========================================================================== */
+  // Convert button to 2-line layout: "Get" on first line, "involved!" on second
+  // This makes the button taller but narrower, preventing text cutoff
+  // 
+  // IMPORTANT: This styling ONLY applies at lg breakpoint (992px-1199px).
+  //            On xl+ screens (1200px+), the button displays normally on one line.
+  .nav-btn {
+    // Button sizing and spacing
+    padding: 0.3rem 0.5rem !important;
+    font-size: calc(#{$sta-font-size-small}px - 1px) !important;
+    line-height: 1.4 !important;
+    min-height: 2.4em;                  // Ensure enough height for 2 lines of text
+    
+    // Text formatting
+    white-space: normal !important;     // Allow text to wrap (not forced to single line)
+    letter-spacing: 0;                  // Normal letter spacing for readability
+    font-weight: 600 !important;        // Slightly bolder for better visibility
+    text-transform: none !important;    // Override uppercase to save space
+    text-align: center;                 // Center-align text within button
+    
+    // Layout and positioning
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    height: auto !important;            // Allow height to adjust to 2-line content
+    min-width: 0;                       // Allow button to shrink if needed
+    flex-shrink: 1;
+    
+    // Fixed width to control text wrapping
+    // Width set to 5.5em to ensure "Get" fits on first line and
+    // "involved!" fits on second line without breaking into 3 lines
+    width: 5.5em !important;
+    max-width: 5.5em !important;
+    min-width: 5.5em !important;
+    
+    // Word breaking behavior
+    word-break: normal;                 // Only break at spaces, not mid-word
+    overflow-wrap: normal;              // Prevent word breaking within words
+    
+    // Emoji styling
+    font-variant-emoji: emoji;
+  }
+
+  /* ==========================================================================
+     Logo Sizing
+     ========================================================================== */
+  // Reduce logo size and margin to create more horizontal space for nav items
+  #navbar-main .navbar-brand {
+    margin-right: 0.4rem !important;    // Reduced margin between logo and nav items
+  }
+  
+  #navbar-main .navbar-brand img {
+    max-height: 48px !important;        // Reduced from default 60px to 48px
+  }
+
+  /* ==========================================================================
+     Container Padding
+     ========================================================================== */
+  // Reduce container padding to maximize available width for navbar content
+  // Note: We don't override max-width to maintain proper content alignment
+  #navbar-main .container {
+    padding-left: 0.5rem !important;    // Reduced from default 15px
+    padding-right: 0.5rem !important;
+  }
+
+  /* ==========================================================================
+     Navbar Collapse Container
+     ========================================================================== */
+  // Optimize navbar-collapse container to use space efficiently
+  // Negative margins reclaim space that would otherwise be padding
+  #navbar-main .navbar-collapse {
+    flex-wrap: nowrap;                  // Prevent items from wrapping to new line
+    overflow: visible;                  // Ensure all content is visible
+    margin-left: -0.5rem;               // Negative margin to reclaim space
+    margin-right: -0.5rem;
+    padding-left: 0;                    // Remove padding to maximize space
+    padding-right: 0;
+  }
+
+  /* ==========================================================================
+     Main Menu Navigation Items
+     ========================================================================== */
+  // Optimize navbar-nav container for efficient space usage
+  #navbar-main .main-menu-item .navbar-nav {
+    flex-wrap: nowrap;                  // Keep items on single line
+    min-width: 0;                       // Allow container to shrink
+    gap: 0;                             // Remove gaps between items
+    margin-left: -0.25rem;              // Negative margin to reclaim space
+    margin-right: -0.25rem;
+  }
+
+  // Reduce margin on main menu item container
+  #navbar-main .main-menu-item {
+    margin-left: -0.5rem;               // Negative margin to reclaim space
+    margin-right: -0.5rem;
+    padding-left: 0;                    // Remove padding
+    padding-right: 0;
+  }
+
+  /* ==========================================================================
+     "Get Involved" Button Container
+     ========================================================================== */
+  // Additional spacing optimizations specifically for the button's nav-item
+  #navbar-main .main-menu-item .nav-item .nav-btn {
+    margin-left: -0.05rem;              // Slight negative margin for tight spacing
+    margin-right: -0.05rem;
+  }
+  
+  // Reduce padding on the last nav-item (which contains the button)
+  #navbar-main .main-menu-item .navbar-nav > .nav-item:last-child {
+    padding-left: 0.05rem !important;   // Minimal padding
+    padding-right: 0.05rem !important;
+  }
+}
+
 @include media-breakpoint-down(md) {
   // Used in conjunction with mobile .navbar-brand to center logo on mobile.
   .navbar-brand-mobile-wrapper {

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -118,7 +118,7 @@
         {{ end }}
 
         <li class="nav-item">
-          <a href="/about/get-involved/" class="nav-link btn btn-primary nav-btn">🚀&nbsp;Get&nbsp;involved!</a>
+          <a href="/about/get-involved/" class="nav-link btn btn-primary nav-btn">🚀 Get Involved!</a>
         </li>
       </ul>
     </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include any relevant information where neccessary. -->

Fixes #195  and #469

At 1024px width (iPad Pro, NestHub, or while resizing the screen), navbar links and the "Get involved" button were being cut off due to insufficient horizontal space. The container width at the `lg` breakpoint (960px) was too narrow to accommodate all navigation items.

## Solution
Optimized spacing, sizing, and layout **only at the `lg` breakpoint (992px - 1199px)** to fit all content without truncation. These optimizations do not affect other screen sizes.


## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration. -->

- [x] Tested Locally
- [ ] Manual review / previewed on [staging.forrt.org](https://staging.forrt.org/)  content/webpage changes

## Checklist for Content Editors and Non-Developers

<!-- This section applies to content, grammar and webpage updates changes: -->

- [x] The content is clear, accurate, and follows community guidelines.
- [ ] All updated content has been previewed on the [staging site](https://staging.forrt.org/).
- [x] All links, references, and formatting have been checked for correctness.
- [x] The change aligns with the overall style and communication goals.
- [x] No broken links in text/content

## Checklist for Developers:

- [x] I have attempted to stay aligned to related code in this repository rather than reinventing the wheel.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Additional Notes
<!-- Add any other context or screenshots here -->
