### PR TITLE
Addressing the security alert identified by dependabot

### DIFF
--- a/.github/workflows/staging-aggregate.yaml
+++ b/.github/workflows/staging-aggregate.yaml
@@ -197,7 +197,7 @@ jobs:
       # =======================
       - name: Try to download data artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: data-processing.yml
@@ -292,7 +292,7 @@ jobs:
       - name: Download data artifact (Retry)
         id: download-artifact-retry
         if: steps.download-artifact.outcome == 'failure' && steps.data-processing.outputs.data_processing_triggered == 'true'
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: data-processing.yml
           name: data-artifact


### PR DESCRIPTION
This PR Updates dawidd6/action-download-artifact to version v6 to address the artifact poisoning vulnerability (GHSA-5xr6-xhww-33m4). This vulnerability allows artifacts from forks to be downloaded by default in versions prior to v6, which can lead to malicious code execution in privileged workflows.

Fixes this notification in security alert [here](https://github.com/forrtproject/forrtproject.github.io/security/dependabot/3) identified by dependabot 

the issue was in staging-aggregate.yaml 

