### PR TITLE
Glossary Fix

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -135,7 +135,7 @@ article.article:has(table) .article-container {
   transition: transform 0.2s;
 }
 
-.pub-abstract {
+.publication-card-abstract {
   display: none;
   margin-bottom: 0.75rem;
   padding: 0.75rem;
@@ -147,11 +147,11 @@ article.article:has(table) .article-container {
   line-height: 1.5;
 }
 
-.pub-abstract.show {
+.publication-card-abstract.show {
   display: block;
 }
 
-.pub-abstract p {
+.publication-card-abstract p {
   margin-bottom: 0;
 }
 

--- a/layouts/shortcodes/publication_list.html
+++ b/layouts/shortcodes/publication_list.html
@@ -88,7 +88,7 @@
                         <i class="fas fa-chevron-right"></i> Show Abstract
                     </button>
                 </div>
-                <div class="pub-abstract">
+                <div class="publication-card-abstract">
                     <p>{{ .abstract | markdownify }}</p>
                 </div>
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include any relevant information where neccessary. -->

Cause: A CSS conflict where the .pub-abstract class (recently added to custom.scss with display: none) was overriding the glossary definition styling.

Fix: I renamed the class to .publication-card-abstract in assets/scss/custom.scss and updated layouts/shortcodes/publication_list.html. 

This ensures the glossary works as before, and the publication list maintains its toggle functionality.

## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration. -->

- [x] Tested Locally
- [ ] Manual review / previewed on [staging.forrt.org](https://staging.forrt.org/)  content/webpage changes

## Checklist for Developers:

- [ ] I have attempted to stay aligned to related code in this repository rather than reinventing the wheel.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Additional Notes
<!-- Add any other context or screenshots here -->
