### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,43 +1,23 @@
 ## Description
-
-<!-- Please include a summary of the change and which issue is fixed. Please also include any relevant information where neccessary. -->
+<!-- Brief summary of the change -->
 
 Fixes # (issue)
 
 ## Type of Change
+- [ ] Content/documentation update
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Breaking change
 
-<!-- Please delete options that are not relevant. -->
+## Testing
+- [ ] Tested locally
+- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)
+- [ ] Not tested yet
 
-- [ ] Documentation/Contents/grammar update
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Bug fix (non-breaking change which fixes an issue)
+## Checklist
+- [ ] Self-reviewed my changes
+- [ ] Verified links and formatting are correct
+- [ ] No new warnings or errors
 
-## How Has This Been Tested?
-
-<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Include any relevant details for your test configuration. -->
-
-- [ ] Tested Locally
-- [ ] Manual review / previewed on [staging.forrt.org](https://staging.forrt.org/)  content/webpage changes
-- [ ] Not Tested yet
-
-## Checklist for Content Editors and Non-Developers
-
-<!-- This section applies to content, grammar and webpage updates changes: -->
-
-- [ ] The content is clear, accurate, and follows community guidelines.
-- [ ] All updated content has been previewed on the [staging site](https://staging.forrt.org/).
-- [ ] All links, references, and formatting have been checked for correctness.
-- [ ] The change aligns with the overall style and communication goals.
-- [ ] No broken links in text/content
-
-## Checklist for Developers:
-
-- [ ] I have attempted to stay aligned to related code in this repository rather than reinventing the wheel.
-- [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
-- [ ] I have made corresponding changes to the documentation.
-- [ ] My changes generate no new warnings.
-
-## Additional Notes
-<!-- Add any other context or screenshots here -->
+## Notes
+<!-- Optional: screenshots or additional context -->


### PR DESCRIPTION
The Pull request template  has too much contents 
This PR shortens it by  merging separate developer/content editor checklists into a single universal checklist with only essential items 