### PR TITLE
fix(seo): Block staging from indexing, add redirects for 404s

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,8 +12,61 @@
 [context.deploy-preview]
   command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
+[context.deploy-preview.environment]
+  HUGO_ENV = "staging"
+
 [context.branch-deploy]
   command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+
+[context.branch-deploy.environment]
+  HUGO_ENV = "staging"
+
+# Redirect old/removed curated resources to the main resources page
+[[redirects]]
+  from = "/curated_resources/*"
+  to = "/resources/"
+  status = 301
+  force = false  # Only redirect if page doesn't exist
+
+# Redirect old/removed glossary terms to the main glossary page
+[[redirects]]
+  from = "/glossary/english/*"
+  to = "/glossary/"
+  status = 301
+  force = false
+
+[[redirects]]
+  from = "/glossary/german/*"
+  to = "/de/glossary/"
+  status = 301
+  force = false
+
+[[redirects]]
+  from = "/glossary/arabic/*"
+  to = "/ar/glossary/"
+  status = 301
+  force = false
+
+# Redirect old author URLs to contributors page
+[[redirects]]
+  from = "/author/*"
+  to = "/contributors/"
+  status = 301
+  force = false
+
+# Redirect old/removed summaries
+[[redirects]]
+  from = "/summaries/*"
+  to = "/"
+  status = 301
+  force = false
+
+# Redirect old/removed reversals
+[[redirects]]
+  from = "/reversals/*"
+  to = "/"
+  status = 301
+  force = false
 
 [[headers]]
   for = "*.webmanifest"

--- a/themes/academic/layouts/404.html
+++ b/themes/academic/layouts/404.html
@@ -22,6 +22,7 @@
       <ul>
         <li><a href="{{ .Site.BaseURL }}about/us">About FORRT</a></li>
         <li><a href="{{ .Site.BaseURL }}about/get-involved/">Get Involved</a></li>
+        <li><a href="{{ .Site.BaseURL }}resources/">Curated Resources</a></li>
         <li><a href="{{ .Site.BaseURL }}glossary/">Glossary</a></li>
         <li><a href="{{ .Site.BaseURL }}replication-hub/">Replication Hub</a></li>
         <li><a href="{{ .Site.BaseURL }}lesson-plans/">Lesson Plans</a></li>

--- a/themes/academic/layouts/robots.txt
+++ b/themes/academic/layouts/robots.txt
@@ -1,7 +1,9 @@
-{{ if eq hugo.Environment "staging" }}
+{{ if eq (getenv "HUGO_ENV") "staging" }}
 User-agent: *
 Disallow: /
 {{ else }}
 User-agent: *
 Allow: /
+
+Sitemap: {{ .Site.BaseURL }}sitemap.xml
 {{ end }}


### PR DESCRIPTION
## Description
<!-- Brief summary of the change -->

Fixes #627 

## Summary

Fixes SEO issues from Google Search Console: staging pages being indexed and 404s from removed or renamed content eg: https://forrt.org/curated_resources/135_library-carpentry-the-unix-shell/ .

##  Changes

- **Netlify previews now blocked from indexing** — Added `HUGO_ENV=staging` for deploy-preview and branch-deploy contexts
- **Standardized env detection** — robots.txt now uses `getenv "HUGO_ENV"` (consistent with site_head.html)
- **Added sitemap to robots.txt** — Helps all search engines discover sitemap automatically
- **301 redirects for stale URLs** — Redirects old `/curated_resources/*`, `/glossary/*`, `/author/*` to active pages
- **Updated 404 page** — Added Curated Resources link

@LukasWallrich I will continue to  Monitor GSC over 2-4 weeks to see the changes 

## Type of Change
- [x] Bug fix

## Testing
- [ ] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
