### PR TITLE
Fix date in workflow and add optional deployment summary on manual run

### DIFF
--- a/.github/workflows/staging-aggregate.yaml
+++ b/.github/workflows/staging-aggregate.yaml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      create_summary:
+        description: 'Create deployment summary (and monthly report if 1st of month)'
+        required: false
+        type: boolean
+        default: false
 
 # Workflow-level concurrency to queue staging builds (wait instead of cancel)
 concurrency:
@@ -407,6 +412,7 @@ jobs:
           path: ${{ github.repository }}/forrt-website
 
       - name: Create deployment summary
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.create_summary == 'true'
         run: |
           echo "## 🚀 Staging Deployment Summary" > deployment-summary.md
           echo "" >> deployment-summary.md
@@ -532,14 +538,14 @@ jobs:
           GH_TOKEN: ${{ secrets.STAGING_GITHUB_TOKEN }}
 
       - name: Create monthly deployment report
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_summary == 'true')
         run: |
           # Only create monthly report on scheduled runs (1st of month)
           CURRENT_DAY=$(date +%d)
           echo "🔍 Current day: $CURRENT_DAY, Event: ${{ github.event_name }}"
           
           if [ "$CURRENT_DAY" = "01" ]; then
-            MONTH=$(date +%B %Y)
+            MONTH=$(date +"%B %Y")
             echo "📊 Creating monthly deployment report for $MONTH"
             
             # Check if deployment summary file exists


### PR DESCRIPTION
## Description
<!-- Brief summary of the change -->

Fixes 
- Fix workflow failure caused by incorrect `date` usage in the monthly report step.
- Add a manual-dispatch option to skip or create the deployment summary. 

## Type of Change
- [x] Bug fix

## Testing
- [ ] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)
- [ ] Not tested yet

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
