### PR TITLE
Fix JSON-LD escaping on Clusters pages (unparsable structured data)

### DIFF
--- a/layouts/partials/clusters/cluster_seo_jsonld.html
+++ b/layouts/partials/clusters/cluster_seo_jsonld.html
@@ -5,9 +5,12 @@
 
 {{ $summary := $p.Params.summary | default $p.Description | default "" }}
 {{ if eq $summary "" }}
-  {{ with $c.description }}{{ $summary = plainify . | truncate 300 "…" }}{{ end }}
+  {{ with $c.description }}{{ $summary = . }}{{ end }}
 {{ end }}
 {{ if eq $summary "" }}{{ $summary = printf "FORRT Cluster %d: %s." (int $c.number) $c.name }}{{ end }}
+{{ $summary = plainify $summary | truncate 300 "…" }}
+{{/* Defense-in-depth: prevent literal </script from terminating the tag */}}
+{{ $summary = replaceRE "(?i)</script" "<\\/script" $summary }}
 
 {{ $hubURL := "clusters/" | absURL }}
 

--- a/layouts/partials/clusters/cluster_seo_jsonld.html
+++ b/layouts/partials/clusters/cluster_seo_jsonld.html
@@ -24,4 +24,4 @@
 
 {{ $graph := slice $webpage $breadcrumb }}
 {{ $root := dict "@context" "https://schema.org" "@graph" $graph }}
-<script type="application/ld+json">{{ $root | jsonify | safeHTML }}</script>
+<script type="application/ld+json">{{ $root | jsonify | safeJS }}</script>

--- a/layouts/partials/clusters/seo_jsonld.html
+++ b/layouts/partials/clusters/seo_jsonld.html
@@ -4,9 +4,12 @@
 
 {{ $summary := .Params.summary | default .Description | default "" }}
 {{ if eq $summary "" }}
-  {{ with .Summary }}{{ $summary = plainify . | truncate 300 "…" }}{{ end }}
+  {{ with .Summary }}{{ $summary = . }}{{ end }}
 {{ end }}
 {{ if eq $summary "" }}{{ $summary = "FORRT open science clusters taxonomy for educators and researchers." }}{{ end }}
+{{ $summary = plainify $summary | truncate 300 "…" }}
+{{/* Defense-in-depth: prevent literal </script from terminating the tag */}}
+{{ $summary = replaceRE "(?i)</script" "<\\/script" $summary }}
 
 {{ $elements := slice }}
 {{ range $i, $c := $data.clusters }}

--- a/layouts/partials/clusters/seo_jsonld.html
+++ b/layouts/partials/clusters/seo_jsonld.html
@@ -27,4 +27,4 @@
 {{ $itemlist := dict "@type" "ItemList" "@id" (printf "%s#itemlist" .Permalink) "name" "FORRT Open Science Clusters" "description" "Full taxonomy of open and reproducible science clusters with sub-clusters and teaching references." "numberOfItems" (len $data.clusters) "itemListElement" $elements }}
 {{ $graph := slice $webpage $itemlist }}
 {{ $root := dict "@context" "https://schema.org" "@graph" $graph }}
-<script type="application/ld+json">{{ $root | jsonify | safeHTML }}</script>
+<script type="application/ld+json">{{ $root | jsonify | safeJS }}</script>


### PR DESCRIPTION
## Description
<!-- Brief summary of the change -->

Fixes invalid JSON-LD on /clusters/ and /clusters/cluster-* pages where Hugo was escaping the JSON into a quoted string, causing “Unparsable structured data”.
Updates the clusters JSON-LD partials to render JSON as safe JavaScript (safeJS) so the <script type="application/ld+json"> contains raw JSON.

## Type of Change
- [x] Bug fix

## Testing
- [x] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
