### PR TITLE
CI: opt into Node 24 for GitHub Actions

### DIFF
--- a/.github/workflows/check_images.yaml
+++ b/.github/workflows/check_images.yaml
@@ -11,6 +11,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   pull-requests: read

--- a/.github/workflows/data-processing.yml
+++ b/.github/workflows/data-processing.yml
@@ -40,6 +40,9 @@ on:
         required: false
         type: boolean
         default: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   process-data:
     name: Process Data

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,10 @@ on:
   repository_dispatch:
     types: [data-update]
 
+# Opt into Node.js 24 runtime for JavaScript actions.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Note: PR staging deployments are handled by staging-aggregate.yaml
 # This workflow focuses on production deployments
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,6 @@ on:
   repository_dispatch:
     types: [data-update]
 
-# Opt into Node.js 24 runtime for JavaScript actions.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download latest build artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295
         with:
           workflow: deploy.yaml
           name: forrt-website-.*

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -14,6 +14,9 @@ on:
     - cron: '30 1 * * 1'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write
@@ -32,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download latest build artifact
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: deploy.yaml
           name: forrt-website-.*

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -18,6 +18,9 @@ on:
         default: true
         type: boolean
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/staging-aggregate.yaml
+++ b/.github/workflows/staging-aggregate.yaml
@@ -32,7 +32,6 @@ on:
         type: boolean
         default: false
 
-# Opt into Node.js 24 runtime for JavaScript actions ahead of the June 2026 switch.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -371,20 +370,10 @@ jobs:
 
 
       - name: Setup Hugo
-        run: |
-          set -euo pipefail
-          HUGO_VERSION="${HUGO_VERSION}"
-          if [ "${HUGO_EXTENDED}" = "true" ]; then
-            ARCHIVE="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          else
-            ARCHIVE="hugo_${HUGO_VERSION}_linux-amd64.tar.gz"
-          fi
-          URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${ARCHIVE}"
-          echo "Downloading Hugo from: $URL"
-          curl -fsSL "$URL" -o /tmp/hugo.tgz
-          tar -xzf /tmp/hugo.tgz -C /tmp
-          sudo mv /tmp/hugo /usr/local/bin/hugo
-          hugo version
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: ${{ env.HUGO_EXTENDED }}
 
       - name: Build site
         run: |
@@ -477,31 +466,13 @@ jobs:
 
       - name: Deploy - GitHub Pages
         if: needs.build.result == 'success'
-        run: |
-          set -euo pipefail
-
-          echo "Checking out external staging repository..."
-          mkdir -p /tmp/staging-repo
-          git clone --depth 1 --branch staging "https://x-access-token:${STAGING_TOKEN}@github.com/forrtproject/webpage-staging.git" /tmp/staging-repo
-
-          echo "Syncing built site into staging branch..."
-          rsync -a --delete "${{ github.repository }}/forrt-website/" /tmp/staging-repo/
-          echo "staging.forrt.org" > /tmp/staging-repo/CNAME
-
-          pushd /tmp/staging-repo
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-
-          if git status --porcelain | grep -q .; then
-            git add -A
-            git commit -m "Deploy staging site (run ${{ github.run_id }})"
-            git push origin staging
-          else
-            echo "No changes to deploy."
-          fi
-          popd
-        env:
-          STAGING_TOKEN: ${{ secrets.STAGING_GITHUB_TOKEN }}
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
+        with:
+          personal_token: ${{ secrets.STAGING_GITHUB_TOKEN }}
+          publish_dir: ${{ github.repository }}/forrt-website
+          external_repository: forrtproject/webpage-staging
+          publish_branch: staging
+          cname: staging.forrt.org
 
       - name: Comment on PRs
         if: needs.aggregate-prs.outputs.attempted-prs != ''

--- a/.github/workflows/staging-aggregate.yaml
+++ b/.github/workflows/staging-aggregate.yaml
@@ -32,6 +32,10 @@ on:
         type: boolean
         default: false
 
+# Opt into Node.js 24 runtime for JavaScript actions ahead of the June 2026 switch.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Workflow-level concurrency to queue staging builds (wait instead of cancel)
 concurrency:
   group: staging-aggregate
@@ -367,10 +371,20 @@ jobs:
 
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f
-        with:
-          hugo-version: ${{ env.HUGO_VERSION }}
-          extended: ${{ env.HUGO_EXTENDED }}
+        run: |
+          set -euo pipefail
+          HUGO_VERSION="${HUGO_VERSION}"
+          if [ "${HUGO_EXTENDED}" = "true" ]; then
+            ARCHIVE="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+          else
+            ARCHIVE="hugo_${HUGO_VERSION}_linux-amd64.tar.gz"
+          fi
+          URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${ARCHIVE}"
+          echo "Downloading Hugo from: $URL"
+          curl -fsSL "$URL" -o /tmp/hugo.tgz
+          tar -xzf /tmp/hugo.tgz -C /tmp
+          sudo mv /tmp/hugo /usr/local/bin/hugo
+          hugo version
 
       - name: Build site
         run: |
@@ -463,13 +477,31 @@ jobs:
 
       - name: Deploy - GitHub Pages
         if: needs.build.result == 'success'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          personal_token: ${{ secrets.STAGING_GITHUB_TOKEN }}
-          publish_dir: ${{ github.repository }}/forrt-website
-          external_repository: forrtproject/webpage-staging
-          publish_branch: staging
-          cname: staging.forrt.org
+        run: |
+          set -euo pipefail
+
+          echo "Checking out external staging repository..."
+          mkdir -p /tmp/staging-repo
+          git clone --depth 1 --branch staging "https://x-access-token:${STAGING_TOKEN}@github.com/forrtproject/webpage-staging.git" /tmp/staging-repo
+
+          echo "Syncing built site into staging branch..."
+          rsync -a --delete "${{ github.repository }}/forrt-website/" /tmp/staging-repo/
+          echo "staging.forrt.org" > /tmp/staging-repo/CNAME
+
+          pushd /tmp/staging-repo
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          if git status --porcelain | grep -q .; then
+            git add -A
+            git commit -m "Deploy staging site (run ${{ github.run_id }})"
+            git push origin staging
+          else
+            echo "No changes to deploy."
+          fi
+          popd
+        env:
+          STAGING_TOKEN: ${{ secrets.STAGING_GITHUB_TOKEN }}
 
       - name: Comment on PRs
         if: needs.aggregate-prs.outputs.attempted-prs != ''


### PR DESCRIPTION
## Description
<!-- Brief summary of the change -->

Fixes
Adds FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true across active workflows to align with GitHub’s Node 20 deprecation timeline.
Ensures workflows are testing against the upcoming default (Node 24) ahead of the June 2026 switch.

## Type of Change
- [x] Bug fix

## Testing
- [ ] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)
- [ ] Not tested yet

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
