### PR TITLE
Exclude partners.json and publications.yaml from data artifact

### DIFF
--- a/.github/workflows/data-processing.yml
+++ b/.github/workflows/data-processing.yml
@@ -444,6 +444,8 @@ jobs:
             content/curated_resources/
             content/glossary/
             data/
+            !data/partners.json
+            !data/publications.yaml
             static/data/
             static/partials/
             content/contributor-analysis/


### PR DESCRIPTION
## Summary

- The data-processing workflow uploads the entire `data/` directory as an artifact, which the deploy workflow then overlays onto the master checkout
- This meant `partners.json` and `publications.yaml` were silently overwritten on every deploy with the version from the last data-processing run — so edits to these files on master wouldn't go live until data-processing ran again
- Adds `!data/partners.json` and `!data/publications.yaml` exclusions to the artifact upload, so the master-branch versions of these hand-curated files are always used

## Test plan

- [ ] Trigger a data-processing run and verify `partners.json`/`publications.yaml` are absent from the artifact
- [ ] Verify the deploy still succeeds and uses the master versions of those files

🤖 Generated with [Claude Code](https://claude.com/claude-code)