### PR TITLE
Update /re-searchterms iframe to re-searchterms-forrt Shiny app

### DIFF
--- a/static/apps/re-searchterms.html
+++ b/static/apps/re-searchterms.html
@@ -17,6 +17,6 @@
       border: none;
   }
 </style>
-    <iframe src="https://msleungyi.shinyapps.io/Re-SearchTerms_v2/"></iframe>
+    <iframe src="https://msleungyi.shinyapps.io/re-searchterms-forrt/"></iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Point the `/re-searchterms` wrapper (`static/apps/re-searchterms.html`) at the new `https://msleungyi.shinyapps.io/re-searchterms-forrt/` Shiny app instead of the older `Re-SearchTerms_v2` deployment.

The existing redirect rule in `layouts/404.html` (`/re-searchterms` → `/apps/re-searchterms.html`) is unchanged.

## Test plan
- [x] Hugo dev server: `/apps/re-searchterms.html` renders the iframe with the new URL
- [x] `/re-searchterms` falls through to the 404 page whose JS redirect maps to `/apps/re-searchterms.html`
- [ ] After deploy, confirm `https://forrt.org/re-searchterms` loads the new Shiny app

🤖 Generated with [Claude Code](https://claude.com/claude-code)