### PR TITLE
Add 404 redirects for upcoming kebab-case repo renames

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -36,7 +36,17 @@
     { pattern: /^\/author(\/|$)/, target: '/contributors/' },
     { pattern: /^\/summaries(\/|$)/, target: '/' },
     { pattern: /^\/reversals(\/|$)/, target: '/' },
-    { pattern: /^\/re-searchterms\/?$/, target: '/apps/re-searchterms.html' }
+    { pattern: /^\/re-searchterms\/?$/, target: '/apps/re-searchterms.html' },
+
+    // Repo rename redirects (kebab-case migration). Order: longer prefixes first.
+    { pattern: /^\/FReD-apps(\/.*)?$/,                      target: '/fred-apps$1' },
+    { pattern: /^\/FReD(\/.*)?$/,                           target: '/fred$1' },
+    { pattern: /^\/flora_zotero(\/.*)?$/,                   target: '/flora-zotero$1' },
+    { pattern: /^\/LoveReplicationsWeek(\/.*)?$/,           target: '/love-replications-week$1' },
+    { pattern: /^\/plugin_notification_dummy(\/.*)?$/,      target: '/plugin-notification-dummy$1' },
+    { pattern: /^\/replication_handbook(\/.*)?$/,           target: '/replication-handbook$1' },
+    { pattern: /^\/TenureRun(\/.*)?$/,                      target: '/tenure-run$1' },
+    { pattern: /^\/Transform-to-Open-Science-Book(\/.*)?$/, target: '/transform-to-open-science-book$1' }
   ];
   for (var i = 0; i < redirects.length; i++) {
     var match = path.match(redirects[i].pattern);


### PR DESCRIPTION
## Summary

Pre-stages 404-handler redirects in `layouts/404.html` for the eight forrtproject repos with GitHub Pages whose names are not yet kebab-case. **This PR should be merged *before* the corresponding repos are renamed.**

| Old path | New path |
| --- | --- |
| `/FReD/…` | `/fred/…` |
| `/FReD-apps/…` | `/fred-apps/…` |
| `/flora_zotero/…` | `/flora-zotero/…` |
| `/LoveReplicationsWeek/…` | `/love-replications-week/…` |
| `/plugin_notification_dummy/…` | `/plugin-notification-dummy/…` |
| `/replication_handbook/…` | `/replication-handbook/…` |
| `/TenureRun/…` | `/tenure-run/…` |
| `/Transform-to-Open-Science-Book/…` | `/transform-to-open-science-book/…` |

## Why this works

GitHub redirects `github.com/forrtproject/<oldname>` → `…/<newname>` automatically, but **does not** redirect Project Pages URLs. Once a repo is renamed, the old `forrt.org/<oldname>/` path no longer matches any project repo, so it falls through to the user-pages site (this repo) and hits Hugo's 404 page. The JS in `layouts/404.html` then matches the path and `window.location.replace()`s to the new URL.

Patterns preserve sub-paths (`/FReD/foo/bar.html` → `/fred/foo/bar.html`) via a single trailing capture group. They are intentionally **case-sensitive** — using `/i` would risk a redirect loop if `/fred/` ever 404'd.

## Why no source-link updates here

Some internal links still reference the old paths:

- `config/_default/menus.toml` (3 entries)
- `static/explorer/index.html`, `static/annotator/index.html` (iframes)
- `content/replication-hub/_index.md`, `content/adopting/adopting.md`

Updating them now would point users at `/fred/`, `/fred-apps/`, etc. *before* those URLs exist, producing 404s in the gap between merge and rename. Those edits belong in a follow-up PR after the renames land.

## Order of operations

1. Merge this PR.
2. Rename the eight repos to kebab-case.
3. Open follow-up PR updating internal links.

## Test plan

- [x] Patterns unit-tested locally against 14 paths (all expected redirects fire; `/fred/`, `/FReDsomething`, `/about/` correctly do not match).
- [ ] After merge, smoke-test one rename end-to-end (e.g., `TenureRun` → `tenure-run`) to confirm the 404 fall-through behaves as expected before doing the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)