### PR TITLE
Update internal links to kebab-case repo paths (post-rename)

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -290,7 +290,7 @@
 
 [[main]]
   name = "Zotero Replication Checker"
-  url = "https://forrt.org/flora_zotero/"
+  url = "https://forrt.org/flora-zotero/"
   weight = 63
   parent = "replications"
 
@@ -302,13 +302,13 @@
 
 [[main]]
   name = "FReD R-Package"
-  url = "https://forrt.org/FReD/index.html"
+  url = "https://forrt.org/fred/index.html"
   weight = 65
   parent = "replications"
 
 [[main]]
   name = "Handbook for Reproductions and Replications"
-  url = "https://forrt.org/replication_handbook/"
+  url = "https://forrt.org/replication-handbook/"
   weight = 66
   parent = "replications"
 

--- a/content/adopting/adopting.md
+++ b/content/adopting/adopting.md
@@ -248,7 +248,7 @@ Involving students in open science projects is an effective way to deepen their 
   * Helpful resources for overall robustness/validity include:  
     * [A Protocol for Structured Robustness Reproductions and Replicability Assessments](https://econpapers.repec.org/paper/zbwi4rdps/143.htm): A list of three different reporting tools used to streamline the presentation of results and assess adherence to pre-analysis plans in the replicated papers, as well as to evaluate external and construct validity.  
     * [Author Guidelines for Verification Reports](https://openpsychologydata.metajnl.com/verification-reports): Guidelines for evaluating claims in published research by reanalysing original study data.   
-    * [FORRT’s 60+ pages guide on reproductions and replications](https://forrt.org/replication_handbook/).  
+    * [FORRT’s 60+ pages guide on reproductions and replications](https://forrt.org/replication-handbook/).  
 * Review and evaluate examples of replication studies and reproducibility reviews found from directories below:  
   * [ReplicationWiki – Economics and social sciences](https://blog.repec.org/2020/08/04/a-replication-database-for-economics-and-social-sciences-the-replicationwiki/)  
   * [Political Science Replication](https://politicalsciencereplication.wordpress.com/about/)  

--- a/content/replication-hub/_index.md
+++ b/content/replication-hub/_index.md
@@ -44,7 +44,7 @@ cards:
       - text: "FReD Explorer"
         url: "/explorer"
       - text: "FReD R Package"
-        url: "/FReD"
+        url: "/fred"
 
   - key: conduct
     title: Conduct
@@ -56,11 +56,11 @@ cards:
       conduct high-quality replication research.
     links:
       - text: "Handbook for Reproduction and Replication Studies (WIP)"
-        url: "/replication_handbook"
+        url: "/replication-handbook"
       - text: "Manuscript Templates"
         url: "https://osf.io/brxtd/"
       - text: "Love Replications Week"
-        url: "/LoveReplicationsWeek"
+        url: "/love-replications-week"
       - text: "ReplicateThis Nomination Portal (WIP)"
         url: "/replicatethis"
 

--- a/static/annotator/index.html
+++ b/static/annotator/index.html
@@ -19,6 +19,6 @@
       border: none;
   }
 </style>
-    <iframe src="https://forrt.org/FReD-apps/annotator/"></iframe>
+    <iframe src="https://forrt.org/fred-apps/annotator/"></iframe>
 </body>
 </html>

--- a/static/explorer/index.html
+++ b/static/explorer/index.html
@@ -19,6 +19,6 @@
       border: none;
   }
 </style>
-    <iframe src="https://forrt.org/FReD-apps/explorer/"></iframe>
+    <iframe src="https://forrt.org/fred-apps/explorer/"></iframe>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to #762. Updates internal links across the Hugo site that still point at old non-kebab-case repo paths, so they go directly to the new URLs instead of relying on the 404 fall-through redirect.

**Do not merge until the eight repo renames have completed**, otherwise the new links will 404. Hence draft.

## Changes

| File | Old → New |
| --- | --- |
| `config/_default/menus.toml` | `/flora_zotero/` → `/flora-zotero/`<br>`/FReD/index.html` → `/fred/index.html`<br>`/replication_handbook/` → `/replication-handbook/` |
| `content/replication-hub/_index.md` | `/FReD` → `/fred`<br>`/replication_handbook` → `/replication-handbook`<br>`/LoveReplicationsWeek` → `/love-replications-week` |
| `content/adopting/adopting.md` | `/replication_handbook/` → `/replication-handbook/` |
| `static/explorer/index.html` (iframe) | `/FReD-apps/explorer/` → `/fred-apps/explorer/` |
| `static/annotator/index.html` (iframe) | `/FReD-apps/annotator/` → `/fred-apps/annotator/` |

Display text mentioning "FReD" (brand name, not URL) is intentionally untouched. The 404-handler redirects added in #762 stay in place to catch external links that still use the old paths.

## Order of operations (reminder from #762)

1. Merge #762 (404 redirects) — DONE.
2. Rename the eight repos to kebab-case.
3. Mark this PR ready and merge.

## Test plan

- [ ] After merge, click each updated link on the live site and confirm 200 (not 301).
- [ ] Open `/explorer/` and `/annotator/` and confirm iframes load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)