### PR TITLE
Update workflow refs from master to main (pre-rename)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ This document describes the GitHub Actions workflows used in the FORRT website r
 │   (daily)       │     │  (production)   │     │   (forrt.org)   │
 └─────────────────┘     └─────────────────┘     └─────────────────┘
                               ▲
-                              │ (master push)
+                              │ (main push)
                               │
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │   Pull Request  │────▶│staging-aggregate│────▶│  staging.forrt  │
@@ -25,7 +25,7 @@ This document describes the GitHub Actions workflows used in the FORRT website r
 
 | Trigger | Target | Schedule |
 |---------|--------|----------|
-| Push to `master` | forrt.org | On push |
+| Push to `main` | forrt.org | On push |
 | Manual dispatch | forrt.org | Manual |
 | Data update event | forrt.org | Triggered by data-processing |
 
@@ -36,7 +36,7 @@ Builds the Hugo site and deploys to GitHub Pages (`gh-pages` branch).
 
 | Trigger | Target | Schedule |
 |---------|--------|----------|
-| PR to `master` | staging.forrt.org | On PR events |
+| PR to `main` | staging.forrt.org | On PR events |
 | Monthly schedule | staging.forrt.org | 1st of month |
 | Manual dispatch | staging.forrt.org | Manual |
 
@@ -110,7 +110,7 @@ Cleans up:
 | Merged branches | Delete all |
 | Stale (1+ month, no PR) | Delete |
 
-Protected branches (never deleted): `master`, `gh-pages`
+Protected branches (never deleted): `main`, `gh-pages`
 
 > Note: `staging-aggregate-*` branches are auto-generated and cleaned up separately (keeping 2 most recent).
 

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -7,7 +7,7 @@ name: Cleanup Branches
 # Triggers: Weekly on Sundays or manual dispatch
 # Jobs:
 #   - cleanup-auto-generated: Removes old ga-data-update-* (keeps 1) and staging-aggregate-* branches (keeps 2)
-#   - cleanup-merged: Removes branches already merged into master
+#   - cleanup-merged: Removes branches already merged into main
 #   - cleanup-stale: Removes branches with no activity for 1+ month (no open PRs)
 
 on:
@@ -113,11 +113,11 @@ jobs:
           git fetch --all --prune --tags
 
           # Define protected branches
-          PROTECTED_BRANCHES="master|gh-pages"
+          PROTECTED_BRANCHES="main|gh-pages"
 
           echo "Finding merged branches..."
-          # List remote branches merged into origin/master, exclude protected ones
-          MERGED_BRANCHES=$(git branch -r --merged origin/master | grep -vE "HEAD|origin/($PROTECTED_BRANCHES)$" | sed 's/origin\///' | xargs)
+          # List remote branches merged into origin/main, exclude protected ones
+          MERGED_BRANCHES=$(git branch -r --merged origin/main | grep -vE "HEAD|origin/($PROTECTED_BRANCHES)$" | sed 's/origin\///' | xargs)
 
           if [ -z "$MERGED_BRANCHES" ]; then
             echo "No merged branches to delete."
@@ -181,7 +181,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Define protected branches
-          PROTECTED_BRANCHES="master|gh-pages"
+          PROTECTED_BRANCHES="main|gh-pages"
 
           echo "Fetching all branches..."
           git fetch --all --prune --tags

--- a/.github/workflows/data-processing.yml
+++ b/.github/workflows/data-processing.yml
@@ -306,7 +306,7 @@ jobs:
           gh pr create \
             --title "📘 Glossary update - $(date '+%Y-%m-%d')" \
             --body "Automated glossary update generated on $(date -u +'%Y-%m-%d %H:%M:%S UTC'). Files changed: content/glossary/" \
-            --base master \
+            --base main \
             --head "$BRANCH_NAME"
           echo "✅ PR created for glossary updates"
         env:
@@ -391,8 +391,8 @@ jobs:
           fi
           
           BRANCH_NAME="ga-data-update-$(date +%Y%m%d-%H%M%S)"
-          git fetch origin master
-          git checkout master
+          git fetch origin main
+          git checkout main
           # Delete local branch if it exists
           git branch -D "$BRANCH_NAME" 2>/dev/null || true
           git checkout -b "$BRANCH_NAME"
@@ -417,7 +417,7 @@ jobs:
           gh pr create \
             --title "📊 Monthly GA Data Update - $(date '+%B %Y')" \
             --body "Automated monthly Google Analytics data update. Generated on $(date -u +'%Y-%m-%d %H:%M:%S UTC'). Files changed: data/ga_data.json" \
-            --base master \
+            --base main \
             --head "$BRANCH_NAME" \
             --label "ga-data,monthly-update"
           echo "✅ PR created for GA data update"
@@ -519,8 +519,8 @@ jobs:
             echo "✓ build-resources branch exists, creating/updating worktree"
             git worktree add -B build-resources "$WORKTREE_DIR" origin/build-resources
           else
-            echo "✓ build-resources does not exist, creating from master"
-            git worktree add -b build-resources "$WORKTREE_DIR" origin/master
+            echo "✓ build-resources does not exist, creating from main"
+            git worktree add -b build-resources "$WORKTREE_DIR" origin/main
           fi
 
           # Apply updates inside the worktree

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,14 +4,14 @@ name: deploy
 # FORRT Website Deployment
 # =======================
 # Purpose: Build and deploy the FORRT Hugo website to production
-# Triggers: Push to master, manual dispatch, or data updates
+# Triggers: Push to main, manual dispatch, or data updates
 # Target: Production (forrt.org)
 # Note: Staging deployments are handled by staging-aggregate.yaml
 
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
   repository_dispatch:
     types: [data-update]
@@ -82,7 +82,7 @@ jobs:
           # Determine branch ref to dispatch (must be a branch or tag)
           REF="${GITHUB_REF#refs/heads/}"
           if [ -z "$REF" ]; then
-            REF="master"
+            REF="main"
           fi
 
           echo "🚀 Dispatching data-processing workflow for ref: $REF because artifact was missing"

--- a/.github/workflows/staging-aggregate.yaml
+++ b/.github/workflows/staging-aggregate.yaml
@@ -4,13 +4,13 @@ name: Staging Aggregate Deployment
 # Staging Deployment Workflow
 # =======================
 # Purpose: Aggregates and deploys staging changes to production
-# Triggers: PRs to master, monthly schedule, or manual dispatch
+# Triggers: PRs to main, monthly schedule, or manual dispatch
 # Features: Multi-PR aggregation, staging deployment, and force deploy option
 
 on:
   pull_request:
     branches:
-      - master
+      - main
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: '0 1 1 * *'  # 1 AM UTC on the 1st of each month
@@ -85,7 +85,7 @@ jobs:
             # Validate PR exists and is open
             if ! gh pr view "$SINGLE_PR" --json state --jq '.state' | grep -q "OPEN"; then
               echo "❌ PR #$SINGLE_PR is not open or doesn't exist"
-              echo "branch=master" >> $GITHUB_OUTPUT
+              echo "branch=main" >> $GITHUB_OUTPUT
               echo "included_prs=" >> $GITHUB_OUTPUT
               echo "attempted_prs=$SINGLE_PR" >> $GITHUB_OUTPUT
               echo "total_prs=0" >> $GITHUB_OUTPUT
@@ -97,12 +97,12 @@ jobs:
             echo "has_prs=true" >> $GITHUB_OUTPUT
             echo "total_prs=1" >> $GITHUB_OUTPUT
           else
-            # Get all open, non-draft PRs targeting master (regardless of CI status)
-            PRS=$(gh pr list --base master --state open --json number,title,headRefName,isDraft --jq '.[] | select(.isDraft == false) | .number')
+            # Get all open, non-draft PRs targeting main (regardless of CI status)
+            PRS=$(gh pr list --base main --state open --json number,title,headRefName,isDraft --jq '.[] | select(.isDraft == false) | .number')
             
             if [ -z "$PRS" ]; then
               echo "No open non-draft PRs found"
-              echo "branch=master" >> $GITHUB_OUTPUT
+              echo "branch=main" >> $GITHUB_OUTPUT
               echo "included_prs=" >> $GITHUB_OUTPUT
               echo "attempted_prs=" >> $GITHUB_OUTPUT
               echo "total_prs=0" >> $GITHUB_OUTPUT
@@ -115,9 +115,9 @@ jobs:
             echo "has_prs=true" >> $GITHUB_OUTPUT
           fi
           
-          # Create a new branch for aggregation starting from master
+          # Create a new branch for aggregation starting from main
           AGGREGATE_BRANCH="staging-aggregate-$(date +%Y%m%d-%H%M%S)"
-          git checkout master
+          git checkout main
           git checkout -b "$AGGREGATE_BRANCH"
           
           INCLUDED_PRS=""
@@ -230,7 +230,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.aggregate-prs.outputs.aggregated-branch || 'master' }}
+          ref: ${{ needs.aggregate-prs.outputs.aggregated-branch || 'main' }}
 
       - name: Configure Git
         run: |
@@ -278,7 +278,7 @@ jobs:
           # Determine branch ref to dispatch (must be a branch or tag)
           REF="${GITHUB_REF#refs/heads/}"
           if [ -z "$REF" ]; then
-            REF="master"
+            REF="main"
           fi
 
           echo "🚀 Dispatching data-processing workflow for ref: $REF because artifact was missing"


### PR DESCRIPTION
## Summary

Prepares for renaming the default branch \`master\` → \`main\`. GitHub's branch-rename API auto-updates open PRs, branch protections, the default-branch setting and HEAD references, but it does **not** rewrite YAML/Markdown file contents. Anything that hard-codes the branch name in a workflow file or docs needs to be patched manually — that's what this PR does.

## Changes

| File | Was | Why |
| --- | --- | --- |
| \`deploy.yaml\` | \`branches: [master]\` trigger, \`REF=\"master\"\` | Triggers wouldn't fire on \`main\` pushes; manual-dispatch fallback would target a missing branch |
| \`staging-aggregate.yaml\` | \`branches: [master]\`, \`gh pr list --base master\`, \`git checkout master\` | Trigger + several shell commands |
| \`cleanup-branches.yml\` | \`origin/master\`, \`PROTECTED_BRANCHES=\"master\\|gh-pages\"\` | Merged-into-default detection + allowlist |
| \`data-processing.yml\` | \`origin master\`, \`git checkout master\`, \`--base master\`, etc. (6 refs) | Auto-update PR creation, worktree setup |
| \`workflows/README.md\` | Docs referring to \`master\` push triggers / protection | Keep docs accurate |

**Intentionally not changed:** \`data-processing.yml:141\` — \`uses: eddelbuettel/github-actions/r2u-setup@master\`. That \`@master\` is the version ref of an *external* action's branch, not ours.

## Order

1. Merge this PR.
2. Run the rename on GitHub (PATCH \`/repos/forrtproject/forrtproject.github.io/branches/master/rename\` → \`new_name=main\`).

Merging this PR before the rename keeps scheduled runs from breaking in the gap — \`branches: [main]\` triggers will be dormant until the rename, but no shell command will try to check out a branch that doesn't exist.

A separate PR on the \`cv\` repo updates its \`destination_branch: 'master'\` (which targets this repo) to \`'main'\`. Both should land before the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)