### PR TITLE
fix path in embed.html

### DIFF
--- a/layouts/shortcodes/embed.html
+++ b/layouts/shortcodes/embed.html
@@ -1,5 +1,5 @@
 <object data="/files/{{ .Get "name" }}" type="application/pdf" width="100%" height="1000px">
     <embed src="/files/{{ .Get "name" }}">
-        <p>This browser does not support PDFs. Please download the PDF to view it: <a href="files/{{ .Get "name" }}">Download PDF</a>.</p>
+        <p>This browser does not support PDFs. Please download the PDF to view it: <a href="/files/{{ .Get "name" }}">Download PDF</a>.</p>
     </embed>
 </object>


### PR DESCRIPTION
## Description

Current code generates incorrect path to files (eg. https://forrt.org/cv/files/FORRT_cv.pdf instead of https://forrt.org/files/FORRT_cv.pdf)

## Type of Change
- [ ] Content/documentation update
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change

## Testing
- [ ] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)
- [ ] Not tested yet

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
