### PR TITLE
Enable JUST-OS chatbot

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -184,7 +184,7 @@ plugins_js  = []
 # `short_message` is shown in the floating-icon hover bubble.
 # `offline_message` is shown on the standalone /just_os_chatbot/ page.
 [justos_chatbot]
-  active = false
+  active = true
   short_message = "Chatbot offline — we hope to bring it back soon"
   offline_message = "We hope to bring it back soon — please check again later."
 


### PR DESCRIPTION
## Summary
- Flips `[justos_chatbot] active` from `false` to `true` in `config/_default/params.toml`
- Per the comment block right above the setting, this is the documented switch to take the chatbot out of its offline state once the JUST-OS backend is healthy
- No other changes — `short_message` / `offline_message` are unused while `active = true`, so they stay as-is for the next time we need to flip it back

## Test plan
- [ ] Confirm the JUST-OS backend is reachable before merging
- [ ] After deploy, check the floating chatbot widget on any page connects (no "Chatbot offline" bubble)
- [ ] Visit `/just_os_chatbot/` and confirm the embedded chat loads instead of the offline message

🤖 Generated with [Claude Code](https://claude.com/claude-code)