### PR TITLE
Update branch name references from master to main

### DIFF
--- a/.github/BUILD_RESOURCES_BRANCH.md
+++ b/.github/BUILD_RESOURCES_BRANCH.md
@@ -135,7 +135,7 @@ If you don't see expected changes:
 ### Merge Conflicts
 
 This branch should never have merge conflicts since:
-- It's not meant to be merged back to master
+- It's not meant to be merged back to main
 - All changes are automated
 - Manual edits are discouraged
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ We will take care of the issue as soon as possible. Right now we run on voluntee
 
 ### Cloning the Repository
 
-For FORRT contributors, you can clone this repository to your local machine and make changes on the feature branch. For now, we do not use a separate development branch. Proposed changes must be made in a feature branch. Please then create a pull request into the master branch.
+For FORRT contributors, you can clone this repository to your local machine and make changes on the feature branch. For now, we do not use a separate development branch. Proposed changes must be made in a feature branch. Please then create a pull request into the main branch.
 
 For external contributors, this website operates on the [fork and pull](https://reflectoring.io/github-fork-and-pull/) model, so you will need to fork this repository to your GitHub account of choice and then clone it to your local machine.
 
@@ -84,7 +84,7 @@ To edit it locally, you will then need to:
 2. Clone this repo you just added in your own account: `git clone https://github.com/yourusername/forrtproject.github.io.git` in a terminal window.
 3. To run the website locally, make sure you are still in `FORRT/` dir and type `hugo server -D` in your terminal.
    - The -D option is to serve the website including draft .md files.
-4.  Create a new branch with your name or the feature you would like to add (e.g. outreach). Depending on your code editor, the way to do this will vary (e.g. in Visual Studio Code you can click on "master" in the bottom left and select "new branch").
+4.  Create a new branch with your name or the feature you would like to add (e.g. outreach). Depending on your code editor, the way to do this will vary (e.g. in Visual Studio Code you can click on "main" in the bottom left and select "new branch").
 5. Make changes on your branch. Check that it the website is working using again `hugo server -D`.
 6. Select what changes you want to add now and "stage" them with Git.
 7. Commit your changes and add a message that describes the changes.
@@ -101,7 +101,7 @@ The FORRT website uses a dual deployment strategy to ensure quality and enable c
 
 - **URL**: [https://forrt.org](https://forrt.org)
 - **Workflow**: `.github/workflows/deploy.yaml`
-- **Trigger**: Pushes to `master` branch
+- **Trigger**: Pushes to `main` branch
 - **Target**: GitHub Pages (`gh-pages` branch)
 - **Purpose**: Serves the live, production website
 
@@ -109,7 +109,7 @@ The FORRT website uses a dual deployment strategy to ensure quality and enable c
 
 - **URL**: [https://staging.forrt.org](https://staging.forrt.org)
 - **Workflow**: `.github/workflows/staging-aggregate.yaml`
-- **Trigger**: Pull requests to `master`, monthly schedule (1st of each month), or manual dispatch
+- **Trigger**: Pull requests to `main`, monthly schedule (1st of each month), or manual dispatch
 - **Target**: External repository (`forrtproject/webpage-staging`)
 - **Purpose**: Preview combined changes from all open PRs
 
@@ -118,8 +118,8 @@ The FORRT website uses a dual deployment strategy to ensure quality and enable c
 The staging deployment uses an **aggregation strategy** to provide a unified preview environment:
 
 1. **Automatic Aggregation**: When any PR is opened, synchronized, or reopened, the workflow:
-   - Collects all open, non-draft PRs targeting `master`
-   - Creates a temporary aggregation branch from `master`
+   - Collects all open, non-draft PRs targeting `main`
+   - Creates a temporary aggregation branch from `main`
    - Attempts to merge each PR in sequence
    
 2. **Conflict Handling**: 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FORRT
 
-[![Hugo CICD](https://github.com/forrtproject/forrtproject.github.io/actions/workflows/deploy.yaml/badge.svg?branch=master)](https://github.com/forrtproject/forrtproject.github.io/actions/workflows/deploy.yaml)
+[![Hugo CICD](https://github.com/forrtproject/forrtproject.github.io/actions/workflows/deploy.yaml/badge.svg?branch=main)](https://github.com/forrtproject/forrtproject.github.io/actions/workflows/deploy.yaml)
 [![pages-build-deployment](https://github.com/forrtproject/forrtproject.github.io/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/forrtproject/forrtproject.github.io/actions/workflows/pages/pages-build-deployment)
 [![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=forrt.org&up_color=blue&up_message=online&url=https%3A%2F%2Fforrt.org%2F)](https://forrt.org)
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -78,7 +78,7 @@ privacy_pack = true
 
 # Enable visitors to edit pages?
 #   `repo` defines the repository URL. `editable` defines which page types can be edited.
-edit_page = {repo_url = "https://github.com/forrtproject/forrt", content_dir = "", repo_branch = "master", editable = {docs = true, page = true, post = true, authors = true, curated_resources = true}}
+edit_page = {repo_url = "https://github.com/forrtproject/forrt", content_dir = "", repo_branch = "main", editable = {docs = true, page = true, post = true, authors = true, curated_resources = true}}
 gh_repo = "https://github.com/forrtproject/forrt"
 
 # Show related content at the bottom of pages?

--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -83,7 +83,7 @@ Link to the FORRT preprint explaining Phase 1
 
 ### Glossary Versioning
 
-We plan to continuously improve, extend, and update our items with community involvement. Versioning will allow the study of the evolution of the terminology. The version-controlled source code of the official releases of the complete Glossary is archived on FORRT’s [GitHub](https://github.com/forrtproject/forrtproject.github.io/tree/master/content/glossary), [OSF](https://osf.io/vdb8z/), and [Zenodo](https://zenodo.org/record/5643745). The present glossary is the Beta 0.1 version and can be accessed from within FORRT website (as will its updates) below:
+We plan to continuously improve, extend, and update our items with community involvement. Versioning will allow the study of the evolution of the terminology. The version-controlled source code of the official releases of the complete Glossary is archived on FORRT’s [GitHub](https://github.com/forrtproject/forrtproject.github.io/tree/main/content/glossary), [OSF](https://osf.io/vdb8z/), and [Zenodo](https://zenodo.org/record/5643745). The present glossary is the Beta 0.1 version and can be accessed from within FORRT website (as will its updates) below:
 
 1. Current Version: [FORRT's Glossary | Phase 1 | Beta version 0.1](/glossary/vbeta)
 

--- a/content/glossary/english/_index.md
+++ b/content/glossary/english/_index.md
@@ -77,7 +77,7 @@ Link to the FORRT preprint explaining Phase 1
 
 ### Glossary Versioning
 
-We plan to continuously improve, extend, and update our items with community involvement. Versioning will allow the study of the evolution of the terminology. The version-controlled source code of the official releases of the complete Glossary is archived on FORRT’s [GitHub](https://github.com/forrtproject/forrtproject.github.io/tree/master/content/glossary), [OSF](https://osf.io/vdb8z/), and [Zenodo](https://zenodo.org/record/5643745). The present glossary is the Beta 0.1 version and can be accessed from within FORRT website (as will its updates) below:
+We plan to continuously improve, extend, and update our items with community involvement. Versioning will allow the study of the evolution of the terminology. The version-controlled source code of the official releases of the complete Glossary is archived on FORRT’s [GitHub](https://github.com/forrtproject/forrtproject.github.io/tree/main/content/glossary), [OSF](https://osf.io/vdb8z/), and [Zenodo](https://zenodo.org/record/5643745). The present glossary is the Beta 0.1 version and can be accessed from within FORRT website (as will its updates) below:
 
 1. Current Version: [FORRT's Glossary | Phase 1 | Beta version 0.1](/glossary/vbeta)
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: master
+  branch: main
 media_folder: 'static/media/'
 public_folder: 'media'
 collections:


### PR DESCRIPTION
## Description
Updates documentation to reflect the renaming of the default branch from master to main. 

## Type of Change
- [X] Content/documentation update
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change

## Testing
- [ ] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)
- [ ] Not tested yet

## Checklist
- [ ] Self-reviewed my changes
- [ ] Verified links and formatting are correct
- [ ] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
