### PR TITLE
Add Nowhere Lab to Educational Nexus menu

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -234,6 +234,12 @@
     parent = "nexus"
 
   [[main]]
+    name = "Nowhere Lab"
+    url = "/nowherelab/"
+    weight = 44.5
+    parent = "nexus"
+
+  [[main]]
     name = "Pedagogies"
     url = "/pedagogies"
     weight = 45


### PR DESCRIPTION
Adds **Nowhere Lab** as a submenu item under Educational NEXUS, linked to `/nowherelab/`.

The entry is placed alphabetically between "Neurodiversity Team" (weight 44) and "Pedagogies" (weight 45), using `weight = 44.5`. The `/nowherelab/` page already exists on `main` (added in #753).

Verified locally: `hugo` builds without errors and the entry renders in the correct menu position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)