### PR TITLE
SEO/GenAI structured data + author profile page rebuild

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -43,7 +43,10 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
 
 # Workaround Hugo publishing taxonomy URLs as plurals - consistently use singular across Academic.
 [permalinks]
-  authors = "/author/:slug/"
+  # `authors` taxonomy permalink removed: author profiles are now plain section
+  # pages under /authors/<slug>/ (see layouts/authors/list.html). The taxonomy
+  # was disabled because it collided with the content/authors/ section, which
+  # suppressed every profile whose term slug matched its folder name.
   tags = "/tag/:slug/"
   categories = "/category/:slug/"
   publication_types = "/publication-type/:slug/"
@@ -81,7 +84,8 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
   tag = "tags"
   category = "categories"
   publication_type = "publication_types"
-  author = "authors"
+  # `author = "authors"` taxonomy disabled: it collided with the content/authors/
+  # section. Author profiles render as section pages at /authors/<slug>/ instead.
   cluster = "FORRT_clusters"
 
 # Related content.
@@ -105,10 +109,6 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
   [[related.indices]]
     name = "categories"
     weight = 70.0
-
-  [[related.indices]]
-    name = "authors"
-    weight = 20.0
 
 [build]
   no404check = true

--- a/content/authors/Karolina-Urbanska/_index.md
+++ b/content/authors/Karolina-Urbanska/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Karolina Urbanska"
+title: "Karolina Urbanska"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Karolina Urbanska"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/Priya-Silverstein/_index.md
+++ b/content/authors/Priya-Silverstein/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Priya Silverstein"
+title: "Priya Silverstein"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Priya Silverstein"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/Samuel-Alarie/_index.md
+++ b/content/authors/Samuel-Alarie/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Samuel Alarie"
+title: "Samuel Alarie"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Samuel Alarie"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/adam-partridge/_index.md
+++ b/content/authors/adam-partridge/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Adam Partridge"
+title: "Adam Partridge"
 
-# Username (this should match the folder name)
-authors:
-- Name "adam-partridge"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/adira-daniel/_index.md
+++ b/content/authors/adira-daniel/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Adira Daniel"
+title: "Adira Daniel"
 
-# Username (this should match the folder name)
-authors:
-- Name "adira-daniel"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/alaa-aldoh/_index.md
+++ b/content/authors/alaa-aldoh/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Alaa Aldoh"
+title: "Alaa Aldoh"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Alaa Aldoh"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/aleksandra-lazic/_index.md
+++ b/content/authors/aleksandra-lazic/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Aleksandra Lazić"
+title: "Aleksandra Lazić"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Aleksandra Lazić"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/alexander-hart/_index.md
+++ b/content/authors/alexander-hart/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Alexander Hart"
+title: "Alexander Hart"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Alexander Hart"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/alice-rees/_index.md
+++ b/content/authors/alice-rees/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Alice Rees"
+title: "Alice Rees"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Alice Rees"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/alicia-tamara-veersma-barredo/_index.md
+++ b/content/authors/alicia-tamara-veersma-barredo/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Alicia Tamara Veersma Barredo"
+title: "Alicia Tamara Veersma Barredo"
 
-# Username (this should match the folder name)
-authors:
-- Name "Alicia Tamara Veersma Barredo"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/amanda-kay-montoya/_index.md
+++ b/content/authors/amanda-kay-montoya/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr. Amanda Kay Montoya"
+title: "Dr. Amanda Kay Montoya"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr. Amanda Kay Montoya"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/amani-aloufi/_index.md
+++ b/content/authors/amani-aloufi/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Amani Aloufi"
+title: "Amani Aloufi"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Amani Aloufi"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/amelie-bret/_index.md
+++ b/content/authors/amelie-bret/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Amélie Bret"
+title: "Amélie Bret"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Amélie Bret"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/amelie-gourdon/_index.md
+++ b/content/authors/amelie-gourdon/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Amelie Gourdon Kanhukamwe"
+title: "Amelie Gourdon Kanhukamwe"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Amelie Gourdon Kanhukamwe"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/anna-meier/_index.md
+++ b/content/authors/anna-meier/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Anna Meier"
+title: "Anna Meier"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Anna Meier"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/annalisa-myer/_index.md
+++ b/content/authors/annalisa-myer/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Annalisa Myer"
+title: "Annalisa Myer"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Annalisa Myer"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/annalise-laplume/_index.md
+++ b/content/authors/annalise-laplume/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Annalise LaPlume"
+title: "Annalise LaPlume"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Annalise LaPlume"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/aoife-omahony/_index.md
+++ b/content/authors/aoife-omahony/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Aoife O'Mahony"
+title: "Aoife O'Mahony"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Aoife O'Mahony"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/ashley-blake/_index.md
+++ b/content/authors/ashley-blake/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Ashley Blake"
+title: "Ashley Blake"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Ashley Blake"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/balazs-aczel/_index.md
+++ b/content/authors/balazs-aczel/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Balazs Aczel"
+title: "Balazs Aczel"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Balazs Aczel"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/ben-saunders/_index.md
+++ b/content/authors/ben-saunders/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Ben Saunders"
+title: "Ben Saunders"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Ben Saunders"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/berit-t-barthelmes-msc/_index.md
+++ b/content/authors/berit-t-barthelmes-msc/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Berit T. Barthelmes, M.Sc."
+title: "Berit T. Barthelmes, M.Sc."
 
-# Username (this should match the folder name)
-authors:
-- "Berit T. Barthelmes, M.Sc."
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/bethan-iley/_index.md
+++ b/content/authors/bethan-iley/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Bethan Iley"
+title: "Bethan Iley"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Bethan Iley"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/bradley-baker/_index.md
+++ b/content/authors/bradley-baker/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Bradley Baker"
+title: "Bradley Baker"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Bradley Baker"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/cass-gheoghe/_index.md
+++ b/content/authors/cass-gheoghe/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Cass Gheoghe"
+title: "Cass Gheoghe"
 
-# Username (this should match the folder name)
-authors:
-- Name "cass-gheoghe"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/catherine-laverty/_index.md
+++ b/content/authors/catherine-laverty/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Catherine Laverty"
+title: "Catherine Laverty"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Catherine Laverty"
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/catia-oliveira/_index.md
+++ b/content/authors/catia-oliveira/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Catia Oliveira"
+title: "Catia Oliveira"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Catia Oliveira"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/charlotte-r-pennington/_index.md
+++ b/content/authors/charlotte-r-pennington/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Charlotte R. Pennington"
+title: "Charlotte R. Pennington"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Charlotte R. Pennington"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/christopher-eaker/_index.md
+++ b/content/authors/christopher-eaker/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Christopher Eaker"
+title: "Christopher Eaker"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Christopher Eaker"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/ciara-egan/_index.md
+++ b/content/authors/ciara-egan/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Ciara Egan"
+title: "Ciara Egan"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Ciara Egan"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/connor-keating/_index.md
+++ b/content/authors/connor-keating/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Connor Keating"
+title: "Connor Keating"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Connor Keating"
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/crystal-steltenpohl/_index.md
+++ b/content/authors/crystal-steltenpohl/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Crystal Steltenpohl"
+title: "Crystal Steltenpohl"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Crystal Steltenpohl"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/daniela-duca/_index.md
+++ b/content/authors/daniela-duca/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Daniela Duca"
+title: "Daniela Duca"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Daniela Duca"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/david-moreau/_index.md
+++ b/content/authors/david-moreau/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "David Moreau"
+title: "David Moreau"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "David Moreau"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/dermot-lynott/_index.md
+++ b/content/authors/dermot-lynott/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dermot Lynott"
+title: "Dermot Lynott"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Dermot Lynott"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/dr-lukas-wallrich/_index.md
+++ b/content/authors/dr-lukas-wallrich/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr Lukas Wallrich"
+title: "Dr Lukas Wallrich"
 
-# Username (this should match the folder name)
-authors:
-- Name "dr-lukas-wallrich"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/dr-sarah-a-sauve/_index.md
+++ b/content/authors/dr-sarah-a-sauve/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr. Sarah A. Sauvé"
+title: "Dr. Sarah A. Sauvé"
 
-# Username (this should match the folder name)
-authors:
-- Name "dr-sarah-a-sauve"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/dr-steven-verheyen/_index.md
+++ b/content/authors/dr-steven-verheyen/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "dr. Steven Verheyen"
+title: "dr. Steven Verheyen"
 
-# Username (this should match the folder name)
-authors:
-- Name "dr-steven-verheyen"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/drlukasroseler/_index.md
+++ b/content/authors/drlukasroseler/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr. Lukas Röseler"
+title: "Dr. Lukas Röseler"
 
-# Username (this should match the folder name)
-authors:
-- Name "drlukasroseler"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/dushime-mudahera-richard/_index.md
+++ b/content/authors/dushime-mudahera-richard/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dushime Mudahera Richard"
+title: "Dushime Mudahera Richard"
 
-# Username (this should match the folder name)
-authors:
-- Name "dushime-mudahera-richard"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/eike-rinke/_index.md
+++ b/content/authors/eike-rinke/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Eike Mark Rinke"
+title: "Eike Mark Rinke"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Eike Mark Rinke"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/filip-dechterenko/_index.md
+++ b/content/authors/filip-dechterenko/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Filip Děchtěrenko"
+title: "Filip Děchtěrenko"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Filip Děchtěrenko"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/flavio-azevedo/_index.md
+++ b/content/authors/flavio-azevedo/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Flavio Azevedo"
+title: "Flavio Azevedo"
 
-# Username (this should match the folder name)
-authors:
-- Name "flavio-azevedo"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/forrt/_index.md
+++ b/content/authors/forrt/_index.md
@@ -1,8 +1,6 @@
 ---
 title: FORRT
 name: FORRT
-authors:
-- forrt
 bio:
 # education:
 #   courses:

--- a/content/authors/fotis-mystakopoulos-phd-student/_index.md
+++ b/content/authors/fotis-mystakopoulos-phd-student/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Fotis Mystakopoulos, PhD Student"
+title: "Fotis Mystakopoulos, PhD Student"
 
-# Username (this should match the folder name)
-authors:
-- Name "Fotis Mystakopoulos, PhD Student"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/gavin-leech/_index.md
+++ b/content/authors/gavin-leech/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Gavin Leech"
+title: "Gavin Leech"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Gavin Leech"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/gilad-feldman/_index.md
+++ b/content/authors/gilad-feldman/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Gilad Feldman"
+title: "Gilad Feldman"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Gilad Feldman"
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/giorgia-andreolli/_index.md
+++ b/content/authors/giorgia-andreolli/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Giorgia Andreolli"
+title: "Giorgia Andreolli"
 
-# Username (this should match the folder name)
-authors:
-- Name "giorgia-andreolli"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/heather-urry/_index.md
+++ b/content/authors/heather-urry/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Heather Urry"
+title: "Heather Urry"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Heather Urry"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/helena-hartmann/_index.md
+++ b/content/authors/helena-hartmann/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Helena Hartmann"
+title: "Helena Hartmann"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Helena Hartmann"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/henrik-schoenemann/_index.md
+++ b/content/authors/henrik-schoenemann/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Henrik Schönemann"
+title: "Henrik Schönemann"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Henrik Schönemann"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/jacob-miranda/_index.md
+++ b/content/authors/jacob-miranda/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Jacob Miranda"
+title: "Jacob Miranda"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Jacob Miranda"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/jade-pickering/_index.md
+++ b/content/authors/jade-pickering/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Jade Pickering"
+title: "Jade Pickering"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Jade Pickering"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/james-bartlett/_index.md
+++ b/content/authors/james-bartlett/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "James Bartlett"
+title: "James Bartlett"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "James Bartlett"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/jan-philipp-roer/_index.md
+++ b/content/authors/jan-philipp-roer/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Jan Philipp Röer"
+title: "Jan Philipp Röer"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Jan Philipp Röer"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/jeef-lees/_index.md
+++ b/content/authors/jeef-lees/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Jeef Lees"
+title: "Jeef Lees"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Jeef Lees"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/joanne-mccuaig/_index.md
+++ b/content/authors/joanne-mccuaig/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Joanne McCuaig"
+title: "Joanne McCuaig"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Joanne McCuaig"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/john-shaw/_index.md
+++ b/content/authors/john-shaw/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr John Shaw"
+title: "Dr John Shaw"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr John Shaw"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/jordan-wagge/_index.md
+++ b/content/authors/jordan-wagge/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Jordan Wagge"
+title: "Jordan Wagge"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- "Jordan Wagge"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/julia-pauquet/_index.md
+++ b/content/authors/julia-pauquet/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Julia Pauquet"
+title: "Julia Pauquet"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Julia Pauquet"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/julia-strand/_index.md
+++ b/content/authors/julia-strand/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Julia Strand"
+title: "Julia Strand"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Julia Strand"
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/julia-wolska/_index.md
+++ b/content/authors/julia-wolska/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Julia Wolska"
+title: "Julia Wolska"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Julia Wolska"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/justin-sulik/_index.md
+++ b/content/authors/justin-sulik/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Justin Sulik"
+title: "Justin Sulik"
 
-# Username (this should match the folder name)
-authors:
-- Name "justin-sulik"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/kai-krautter/_index.md
+++ b/content/authors/kai-krautter/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Kai Krautter"
+title: "Kai Krautter"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Kai Krautter"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/kaili-chung/_index.md
+++ b/content/authors/kaili-chung/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Kai Li Chung"
+title: "Kai Li Chung"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Kai Li Chung"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/kamil-izydorczak/_index.md
+++ b/content/authors/kamil-izydorczak/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Kamil Izydorczak"
+title: "Kamil Izydorczak"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Kamil Izydorczak"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/karen-matvienko-sikar/_index.md
+++ b/content/authors/karen-matvienko-sikar/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Karen Matvienko-Sikar"
+title: "Karen Matvienko-Sikar"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "karen-matvienko-sikar"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/karen-matvienkosikar/_index.md
+++ b/content/authors/karen-matvienkosikar/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Karen Matvienko-Sikar"
+title: "Karen Matvienko-Sikar"
 
-# Username (this should match the folder name)
-authors:
-- Name "karen-matvienkosikar"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/kelly-lloyd/_index.md
+++ b/content/authors/kelly-lloyd/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr Kelly Lloyd"
+title: "Dr Kelly Lloyd"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr Kelly Lloyd"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/kimberly-quinn/_index.md
+++ b/content/authors/kimberly-quinn/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Kimberly Quinn"
+title: "Kimberly Quinn"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- "Kimberly Quinn"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/laurel-standiford/_index.md
+++ b/content/authors/laurel-standiford/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Laurel Standiford"
+title: "Laurel Standiford"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Laurel Standiford"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/leticia-micheli/_index.md
+++ b/content/authors/leticia-micheli/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Leticia Micheli"
+title: "Leticia Micheli"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Leticia Micheli"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/lorna-hamilton/_index.md
+++ b/content/authors/lorna-hamilton/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Lorna Hamilton"
+title: "Lorna Hamilton"
 
-# Username (this should match the folder name)
-authors:
-- Name "lorna-hamilton"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/louise-bezuidenhout/_index.md
+++ b/content/authors/louise-bezuidenhout/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Louise Bezuidenhout"
+title: "Louise Bezuidenhout"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Louise Bezuidenhout"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/lydia-riedl/_index.md
+++ b/content/authors/lydia-riedl/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Lydia Riedl"
+title: "Lydia Riedl"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Lydia Riedl"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/madeleine-pownall/_index.md
+++ b/content/authors/madeleine-pownall/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr Madeleine Pownall"
+title: "Dr Madeleine Pownall"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr Madeleine Pownall"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/magdelna-grose-hodge/_index.md
+++ b/content/authors/magdelna-grose-hodge/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Magdalena Grose-Hodge"
+title: "Magdalena Grose-Hodge"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- "Magdalena Grose-Hodge"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/mahmoud-elsherif/_index.md
+++ b/content/authors/mahmoud-elsherif/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Mahmoud Elsherif"
+title: "Mahmoud Elsherif"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Mahmoud Elsherif"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/malika-ihle/_index.md
+++ b/content/authors/malika-ihle/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Malika Ihle"
+title: "Malika Ihle"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Malika Ihle"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/markus-konkol/_index.md
+++ b/content/authors/markus-konkol/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Markus Konkol"
+title: "Markus Konkol"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Markus Konkol"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/martin-vasilev/_index.md
+++ b/content/authors/martin-vasilev/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Martin Vasilev"
+title: "Martin Vasilev"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Martin Vasilev"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/max-korbmacher/_index.md
+++ b/content/authors/max-korbmacher/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr Max Korbmacher"
+title: "Dr Max Korbmacher"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr Max Korbmacher"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/meera-chandra/_index.md
+++ b/content/authors/meera-chandra/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Meera Chandra"
+title: "Meera Chandra"
 
-# Username (this should match the folder name)
-authors:
-- Name "meera-chandra"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/mehdi-goughari/_index.md
+++ b/content/authors/mehdi-goughari/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Mehdi Shaahdadi Goughari"
+title: "Mehdi Shaahdadi Goughari"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Mehdi Shaahdadi Goughari"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/meng-liu/_index.md
+++ b/content/authors/meng-liu/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Meng Liu"
+title: "Meng Liu"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Meng Liu"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/mike-galang/_index.md
+++ b/content/authors/mike-galang/_index.md
@@ -1,6 +1,4 @@
 ---
-authors:
-- Mike Galang
 bio: 
 # education:
 #   courses:
@@ -19,6 +17,7 @@ email: ""
 # - Computational Linguistics
 # - Information Retrieval
 name: Mike Galang
+title: "Mike Galang"
 # organizations:
 # - name: Stanford University
 #   url: ""

--- a/content/authors/monica-gonzales-marquez/_index.md
+++ b/content/authors/monica-gonzales-marquez/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Monica Gonzales-Marquez"
+title: "Monica Gonzales-Marquez"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- "Monica Gonzales-Marquez"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/myriam-baum/_index.md
+++ b/content/authors/myriam-baum/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Myriam Baum"
+title: "Myriam Baum"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Myriam Baum"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/nihan-albayrak-aydemir/_index.md
+++ b/content/authors/nihan-albayrak-aydemir/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Nihan Albayrak-Aydemir"
+title: "Nihan Albayrak-Aydemir"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Nihan Albayrak-Aydemir"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/olly-robertson/_index.md
+++ b/content/authors/olly-robertson/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Olly Robertson"
+title: "Olly Robertson"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Olly Robertson"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/patrick-s-forscher/_index.md
+++ b/content/authors/patrick-s-forscher/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Patrick Forscher"
+title: "Patrick Forscher"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Patrick Forscher"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/rachel-heyard/_index.md
+++ b/content/authors/rachel-heyard/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr Rachel Heyard"
+title: "Dr Rachel Heyard"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr Rachel Heyard"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/rachel-renbarger/_index.md
+++ b/content/authors/rachel-renbarger/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Rachel Renbarger"
+title: "Rachel Renbarger"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Rachel Renbarger"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sam-parsons/_index.md
+++ b/content/authors/sam-parsons/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sam Parsons"
+title: "Sam Parsons"
 
-# Username (this should match the folder name)
-authors:
-- Name "sam-parsons"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sam-westwood/_index.md
+++ b/content/authors/sam-westwood/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sam Westwood"
+title: "Sam Westwood"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Sam Westwood"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/samantha-tyler/_index.md
+++ b/content/authors/samantha-tyler/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Samantha Tyler"
+title: "Samantha Tyler"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Samantha Tyler"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/samuel-guay/_index.md
+++ b/content/authors/samuel-guay/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Samuel Guay"
+title: "Samuel Guay"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Samuel Guay"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sandra-grinschgl/_index.md
+++ b/content/authors/sandra-grinschgl/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sandra Grinschgl"
+title: "Sandra Grinschgl"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Sandra Grinschgl"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sara-lil-middleton/_index.md
+++ b/content/authors/sara-lil-middleton/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sara Lil Middleton"
+title: "Sara Lil Middleton"
 
-# Username (this should match the folder name)
-authors:
-- Name "sara-lil-middleton"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sara-middleton/_index.md
+++ b/content/authors/sara-middleton/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sara Middleton"
+title: "Sara Middleton"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Sara Middleton"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sarah-ashcroftjones/_index.md
+++ b/content/authors/sarah-ashcroftjones/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Dr Sarah Ashcroft-Jones"
+title: "Dr Sarah Ashcroft-Jones"
 
-# Username (this should match the folder name)
-authors:
-- Name "Dr Sarah Ashcroft-Jones"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sau-chin-chen/_index.md
+++ b/content/authors/sau-chin-chen/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sau-Chin Chen"
+title: "Sau-Chin Chen"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Sau-Chin Chen"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/shilaan-alzahawi/_index.md
+++ b/content/authors/shilaan-alzahawi/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Shilaan Alzahawi"
+title: "Shilaan Alzahawi"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Shilaan Alzahawi"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/siu-kit-yeung/_index.md
+++ b/content/authors/siu-kit-yeung/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Siu Kit Yeung"
+title: "Siu Kit Yeung"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Siu Kit Yeung"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/sonia-rishi/_index.md
+++ b/content/authors/sonia-rishi/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Sonia Rishi"
+title: "Sonia Rishi"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Sonia Rishi"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/stephanie-zellers/_index.md
+++ b/content/authors/stephanie-zellers/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Stephanie Zellers"
+title: "Stephanie Zellers"
 
-# Username (this should match the folder name)
-authors:
-- Name "stephanie-zellers"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/susanne-vogel/_index.md
+++ b/content/authors/susanne-vogel/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Susanne Vogel"
+title: "Susanne Vogel"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Susanne Vogel"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/tamara-kalandadze/_index.md
+++ b/content/authors/tamara-kalandadze/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Tamara Kalandadze"
+title: "Tamara Kalandadze"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Tamara Kalandadze"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/tamara-marques/_index.md
+++ b/content/authors/tamara-marques/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Tamara Marques"
+title: "Tamara Marques"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Tamara Marques"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/thomas-rhys-evans/_index.md
+++ b/content/authors/thomas-rhys-evans/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Thomas Rhys Evans"
+title: "Thomas Rhys Evans"
 
-# Username (this should match the folder name)
-authors:
-- Name "thomas-rhys-evans"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/timo-roettger/_index.md
+++ b/content/authors/timo-roettger/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Timo B. Roettger"
+title: "Timo B. Roettger"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Timo B. Roettger"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/tina-lonsdorf/_index.md
+++ b/content/authors/tina-lonsdorf/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Tina Lonsdorf"
+title: "Tina Lonsdorf"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Tina Lonsdorf"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/tom-heyman/_index.md
+++ b/content/authors/tom-heyman/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Tom Heyman"
+title: "Tom Heyman"
 
-# Username (this should match the folder name)
-authors:
-- Name "tom-heyman"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/waleed-alsubhi/_index.md
+++ b/content/authors/waleed-alsubhi/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Waleed Alsubhi"
+title: "Waleed Alsubhi"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Waleed Alsubhi"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/william-ngiam/_index.md
+++ b/content/authors/william-ngiam/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "William Ngiam"
+title: "William Ngiam"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "William Ngiam"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/yanna-weisberg/_index.md
+++ b/content/authors/yanna-weisberg/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Yanna Weisberg"
+title: "Yanna Weisberg"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Yanna Weisberg"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/yufang-yang/_index.md
+++ b/content/authors/yufang-yang/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Yu-Fang Yang"
+title: "Yu-Fang Yang"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Yu-Fang Yang"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/zoe-flack/_index.md
+++ b/content/authors/zoe-flack/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Zoe Flack"
+title: "Zoe Flack"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Zoe Flack"
 
 # Is this the primary user of the site?
 superuser: false

--- a/content/authors/zoran-pavlovic/_index.md
+++ b/content/authors/zoran-pavlovic/_index.md
@@ -1,10 +1,8 @@
 ---
 # Display name
 name: "Zoran Pavlović"
+title: "Zoran Pavlović"
 
-# Username (this should match the folder name and the name on publications)
-authors:
-- Name "Zoran Pavlović"
 
 # Is this the primary user of the site?
 superuser: false

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -1,33 +1,117 @@
 {{- define "main" -}}
+{{- $page := . -}}
 
-{{/* Author profile page. */}}
+{{- if $page.Params.name -}}
+{{/* =========================================================================
+     Author profile page  (/authors/<slug>/)
+     Rendered as a plain section page — the `author` taxonomy was disabled
+     because it collided with the content/authors/ section. The profile data
+     (name, role, organizations, bio, social, avatar) comes straight from this
+     page's front matter; the post list is gathered by scanning the site for
+     content that credits this author.
+     ========================================================================= */}}
+  {{- $slug := $page.File.ContentBaseName -}}
+  {{- $name := $page.Params.name | default $page.Title -}}
+  {{- $avatar := ($page.Resources.ByType "image").GetMatch "*avatar*" -}}
+  {{- $avatar_shape := site.Params.avatar.shape | default "circle" -}}
 
-{{/* If an account has not been created for this user, just display their name as the title. */}}
-{{ if not .File }}
-<div class="universal-wrapper pt-3">
-  <h1>{{ .Title }}</h1>
-</div>
-{{ end }}
+  {{/* Collect this author's content (matched by slug or exact display name). */}}
+  {{- $posts := slice -}}
+  {{- range site.RegularPages -}}
+    {{- $p := . -}}
+    {{- $match := false -}}
+    {{- range $p.Params.authors -}}
+      {{- if or (eq (urlize .) $slug) (eq . $name) -}}{{- $match = true -}}{{- end -}}
+    {{- end -}}
+    {{- if $match -}}{{- $posts = $posts | append $p -}}{{- end -}}
+  {{- end -}}
+  {{- $posts = sort $posts "Date" "desc" -}}
 
 <section id="profile-page" class="pt-5">
   <div class="container">
-    {{/* Show the About widget if an account exists for this user. */}}
+    <div class="row">
 
-    {{ $query := where .Pages ".IsNode" false }}
-    {{ $count := len $query }}
-    {{ if $count }}
-    <div class="article-widget content-widget-hr">
-      <h3>{{ i18n "user_profile_latest" | default "Latest" }}</h3>
-      <ul>
-        {{ range $query }}
-        <li>
-          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-        </li>
+      <div class="col-12 col-lg-4">
+        <div id="profile">
+          {{ with $avatar }}
+            {{ $img := .Fill "270x270 Center" }}
+            <img class="avatar {{ if eq $avatar_shape "square" }}avatar-square{{ else }}avatar-circle{{ end }}" src="{{ $img.RelPermalink }}" alt="{{ $name }}" loading="lazy">
+          {{ end }}
+          <div class="portrait-title">
+            <h2>{{ $name }}</h2>
+            {{ with $page.Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
+            {{ range $page.Params.organizations }}
+            <h3>
+              {{ with .url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
+              <span>{{ .name }}</span>
+              {{ if .url }}</a>{{ end }}
+            </h3>
+            {{ end }}
+          </div>
+
+          <ul class="network-icon" aria-hidden="true">
+            {{ range $page.Params.social }}
+              {{ $pack := or .icon_pack "fas" }}
+              {{ $pack_prefix := $pack }}
+              {{ if in (slice "fab" "fas" "far" "fal") $pack }}{{ $pack_prefix = "fa" }}{{ end }}
+              {{ $link := .link }}
+              {{ $scheme := (urls.Parse $link).Scheme }}
+              {{ $target := "" }}
+              {{ if not $scheme }}{{ $link = .link | relLangURL }}{{ else if in (slice "http" "https") $scheme }}{{ $target = "target=\"_blank\" rel=\"noopener\"" }}{{ end }}
+              <li>
+                <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
+                  <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }} big-icon"></i>
+                </a>
+              </li>
+            {{ end }}
+          </ul>
+        </div>
+      </div>
+
+      <div class="col-12 col-lg-8">
+        {{ with $page.Params.bio }}{{ . | markdownify | emojify }}{{ end }}
+        {{ $page.Content }}
+
+        {{/* Interests, dropping the Wowchemy template placeholders ("Interest 1"). */}}
+        {{ $interests := slice }}
+        {{ range $page.Params.interests }}
+          {{ if not (findRE `(?i)^interest \d+$` .) }}{{ $interests = $interests | append . }}{{ end }}
         {{ end }}
-      </ul>
+        {{ with $interests }}
+        <h3>{{ i18n "interests" | default "Interests" | markdownify }}</h3>
+        <ul class="ul-interests">
+          {{ range . }}<li>{{ . | markdownify | emojify }}</li>{{ end }}
+        </ul>
+        {{ end }}
+
+        {{ with $posts }}
+        <div class="article-widget content-widget-hr">
+          <h3>{{ i18n "user_profile_latest" | default "Latest" }}</h3>
+          <ul>
+            {{ range . }}<li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>{{ end }}
+          </ul>
+        </div>
+        {{ end }}
+      </div>
+
     </div>
-    {{ end }}
   </div>
 </section>
 
+{{- else -}}
+{{/* =========================================================================
+     Authors index  (/authors/) — lists every author who has a profile page.
+     ========================================================================= */}}
+<section class="pt-5">
+  <div class="universal-wrapper">
+    <h1>{{ $page.Title | default "Authors" }}</h1>
+    {{ $page.Content }}
+    <ul class="authors-index">
+      {{ range $page.Pages.ByParam "name" }}
+        <li><a href="{{ .RelPermalink }}">{{ .Params.name | default .Title }}</a></li>
+      {{ end }}
+    </ul>
+  </div>
+</section>
+{{- end -}}
 {{- end -}}

--- a/layouts/partials/authors/is-substantive.html
+++ b/layouts/partials/authors/is-substantive.html
@@ -1,0 +1,20 @@
+{{/* Returns true if an author profile page has enough content to be worth
+     indexing: a bio, a role, a real organisation, real (non-placeholder)
+     interests, or at least one piece of credited content on the site.
+     Used to noindex empty template-stub profiles. Call: partial with the page. */}}
+{{- $page := . -}}
+{{- $sub := false -}}
+{{- with $page.Params.bio }}{{ $sub = true }}{{ end -}}
+{{- with $page.Params.role }}{{ $sub = true }}{{ end -}}
+{{- range $page.Params.organizations }}{{ with .name }}{{ $sub = true }}{{ end }}{{ end -}}
+{{- range $page.Params.interests }}{{ if not (findRE `(?i)^interest \d+$` .) }}{{ $sub = true }}{{ end }}{{ end -}}
+{{- if not $sub -}}
+  {{- $slug := $page.File.ContentBaseName -}}
+  {{- $name := $page.Params.name -}}
+  {{- range site.RegularPages -}}
+    {{- range .Params.authors -}}
+      {{- if or (eq (urlize .) $slug) (eq . $name) }}{{ $sub = true }}{{ end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $sub -}}

--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -2,3 +2,19 @@
 {{ with .Params.keywords }}
   <meta name="keywords" content="{{ delimit . ", " }}">
 {{ end }}
+
+{{/* Structured data (JSON-LD) for richer search / GenAI results.
+     Each partial self-gates on page type, so only matching pages emit. */}}
+{{ partial "structured-data/glossary-term.html" . }}
+{{ partial "structured-data/educators-corner.html" . }}
+
+{{/* Author profile pages: noindex empty template stubs, and emit Person
+     structured data for the substantive ones. (Computed once.) */}}
+{{ if and (eq .Section "authors") .Params.name }}
+  {{ $substantive := partial "authors/is-substantive.html" . }}
+  {{ if $substantive }}
+    {{ partial "structured-data/author.html" . }}
+  {{ else }}
+  <meta name="robots" content="noindex, follow">
+  {{ end }}
+{{ end }}

--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -1,0 +1,29 @@
+{{/* Display author list (byline).
+
+     Project override of the theme partial: the `author` taxonomy was disabled,
+     so profiles now live at /authors/<slug>/ as section pages. Posts credit
+     authors by display name (e.g. "Anna Meier"), so we slugify the name with
+     `urlize` to find the matching profile page and link to it. Names that don't
+     resolve to a profile (e.g. multi-name strings) render as plain text. */}}
+
+{{ with .Param "authors" }}
+  {{ $link_authors := site.Params.link_authors | default true }}
+  {{ range $index, $name_raw := . }}
+    {{- $profile_page := site.GetPage (printf "/authors/%s" (urlize $name_raw)) -}}
+    {{- $name := $name_raw -}}
+    {{- if and $profile_page $profile_page.Params.name }}{{ $name = $profile_page.Params.name }}{{ end -}}
+    {{- if gt $index 0 }}, {{ end -}}
+    <span {{ if site.Params.highlight_superuser | and (eq (and $profile_page $profile_page.Params.superuser) true) }}class="font-weight-bold"{{ end }}>
+      {{- if and $profile_page $profile_page.Params.name $link_authors -}}
+        <a href="{{ $profile_page.RelPermalink }}">{{ $name }}</a>
+      {{- else -}}
+        {{ $name }}
+      {{- end -}}
+    </span>
+    {{- if isset $.Params "author_notes" -}}
+      {{- with (index $.Params.author_notes $index) -}}
+        <span title="{{ . }}" class="author-notes">(?)</span>
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/structured-data/author.html
+++ b/layouts/partials/structured-data/author.html
@@ -1,0 +1,40 @@
+{{/* Person JSON-LD for substantive author profile pages (/authors/<slug>/).
+     Called from custom_head.html only for author pages that pass the
+     is-substantive check, so empty stubs never emit a Person. Built with
+     dict + jsonify + safeJS for safe JSON escaping. */}}
+{{- $name := .Params.name | default .Title -}}
+{{- $person := dict
+    "@context" "https://schema.org"
+    "@type" "Person"
+    "name" $name
+    "url" .Permalink -}}
+
+{{- with .Params.role }}{{ $person = merge $person (dict "jobTitle" .) }}{{ end -}}
+{{- with .Params.bio }}{{ $person = merge $person (dict "description" (. | plainify)) }}{{ end -}}
+
+{{/* Affiliations (skip blank template entries) */}}
+{{- $affs := slice -}}
+{{- range .Params.organizations -}}
+  {{- with .name -}}{{ $affs = $affs | append (dict "@type" "Organization" "name" .) }}{{- end -}}
+{{- end -}}
+{{- with $affs }}{{ $person = merge $person (dict "affiliation" .) }}{{ end -}}
+
+{{/* External profile links → sameAs (skip mailto and relative links) */}}
+{{- $sameAs := slice -}}
+{{- range .Params.social -}}
+  {{- if and .link (hasPrefix .link "http") }}{{ $sameAs = $sameAs | append .link }}{{ end -}}
+{{- end -}}
+{{- with $sameAs }}{{ $person = merge $person (dict "sameAs" .) }}{{ end -}}
+
+{{/* Interests → knowsAbout, dropping placeholders */}}
+{{- $topics := slice -}}
+{{- range .Params.interests -}}
+  {{- if not (findRE `(?i)^interest \d+$` .) }}{{ $topics = $topics | append . }}{{ end -}}
+{{- end -}}
+{{- with $topics }}{{ $person = merge $person (dict "knowsAbout" .) }}{{ end -}}
+
+{{/* Avatar image */}}
+{{- $avatar := (.Resources.ByType "image").GetMatch "*avatar*" -}}
+{{- with $avatar }}{{ $person = merge $person (dict "image" .Permalink) }}{{ end -}}
+
+<script type="application/ld+json">{{ $person | jsonify | safeJS }}</script>

--- a/layouts/partials/structured-data/educators-corner.html
+++ b/layouts/partials/structured-data/educators-corner.html
@@ -1,0 +1,29 @@
+{{/* Article JSON-LD for Educators' Corner posts. */}}
+{{- if and (eq .Type "educators-corner") .IsPage -}}
+  {{- $descSrc := .Params.summary | default .Summary -}}
+  {{- $desc := $descSrc | plainify | truncate 300 "…" -}}
+  {{- $desc = replaceRE "(?i)</script" "<\\/script" $desc -}}
+  {{- $authors := slice -}}
+  {{- range .Params.authors -}}
+    {{- $authors = $authors | append (dict "@type" "Person" "name" .) -}}
+  {{- end -}}
+  {{- $org := dict
+      "@type" "Organization"
+      "name" "FORRT"
+      "url" "https://forrt.org"
+      "logo" (dict "@type" "ImageObject" "url" (absURL "img/FORRT.svg")) -}}
+  {{- $article := dict
+      "@context" "https://schema.org"
+      "@type" "Article"
+      "headline" .Title
+      "url" .Permalink
+      "mainEntityOfPage" .Permalink
+      "datePublished" (.Date.Format "2006-01-02")
+      "dateModified" (.Lastmod.Format "2006-01-02")
+      "publisher" $org
+      "about" (dict "@type" "Thing" "name" "Open and Reproducible Science") -}}
+  {{- with $desc }}{{ $article = merge $article (dict "description" .) }}{{ end -}}
+  {{- with $authors }}{{ $article = merge $article (dict "author" .) }}{{ end -}}
+  {{- with .Params.tags }}{{ $article = merge $article (dict "keywords" (delimit . ", ")) }}{{ end -}}
+  <script type="application/ld+json">{{ $article | jsonify | safeJS }}</script>
+{{- end -}}

--- a/layouts/partials/structured-data/glossary-term.html
+++ b/layouts/partials/structured-data/glossary-term.html
@@ -1,0 +1,26 @@
+{{/* DefinedTerm JSON-LD for individual glossary term pages.
+     Built with dict + jsonify + safeJS (see clusters/seo_jsonld.html) so that
+     all values are safely JSON-escaped rather than hand-interpolated. */}}
+{{- if and (eq .Type "glossary") .IsPage .Params.definition -}}
+  {{/* Strip stray markdown emphasis markers (the source occasionally has
+       malformed bold like **"** that CommonMark leaves literal). */}}
+  {{- $desc := .Params.definition | plainify | replaceRE `\*+` "" | truncate 300 "…" -}}
+  {{/* Defense-in-depth: stop a literal </script from terminating the tag. */}}
+  {{- $desc = replaceRE "(?i)</script" "<\\/script" $desc -}}
+  {{- $langMap := dict "arabic" "ar" "chinese" "zh" "english" "en" "german" "de" "turkish" "tr" -}}
+  {{- $lang := index $langMap (.Params.language | default "english") | default "en" -}}
+  {{- $set := dict
+      "@type" "DefinedTermSet"
+      "name" "FORRT Glossary of Open and Reproducible Science"
+      "url" (absURL "glossary/")
+      "inLanguage" $lang -}}
+  {{- $term := dict
+      "@context" "https://schema.org"
+      "@type" "DefinedTerm"
+      "name" .Title
+      "description" $desc
+      "url" .Permalink
+      "inLanguage" $lang
+      "inDefinedTermSet" $set -}}
+  <script type="application/ld+json">{{ $term | jsonify | safeJS }}</script>
+{{- end -}}

--- a/layouts/partials/structured-data/summaries-jsonld.html
+++ b/layouts/partials/structured-data/summaries-jsonld.html
@@ -1,0 +1,50 @@
+{{/* CollectionPage + ScholarlyArticle JSON-LD for the Open & Reproducible
+     Science Summaries pages. The summaries live in data/summaries.json and are
+     rendered as anchored sections on a single page, so each entry is exposed as
+     a ScholarlyArticle whose url points at its in-page anchor.
+
+     Call with: (dict "page" $page "deiOnly" <bool>)
+       deiOnly true  -> only the DEI-tagged summaries (⌺), matching summaries_dei
+       deiOnly false -> all summaries, matching the summaries shortcode
+
+     DOIs are extracted from the stored APA reference; if none is present the
+     identifier is simply omitted (never guessed). */}}
+{{- $page := .page -}}
+{{- $deiOnly := .deiOnly -}}
+{{- $parts := slice -}}
+{{- range $s := site.Data.summaries -}}
+  {{- if or (not $deiOnly) (in $s.Title "⌺") -}}
+    {{/* Clean the title: drop the ◈ / ⌺ status symbols and any markdown. */}}
+    {{- $name := trim ($s.Title | replaceRE "[◈⌺]" "" | plainify) " " -}}
+    {{- $url := printf "%s#%s" $page.Permalink $s.Id -}}
+    {{- $article := dict
+        "@type" "ScholarlyArticle"
+        "name" $name
+        "headline" $name
+        "url" $url
+        "inLanguage" "en"
+        "publisher" (dict "@type" "Organization" "name" "FORRT" "url" "https://forrt.org") -}}
+    {{- with $s.Abstract -}}
+      {{- $abs := . | plainify | truncate 500 "…" -}}
+      {{- $abs = replaceRE "(?i)</script" "<\\/script" $abs -}}
+      {{- $article = merge $article (dict "abstract" $abs) -}}
+    {{- end -}}
+    {{- $dois := findRE `10\.\d{4,9}/[^\s)\]]+` ($s.Reference | default "") 1 -}}
+    {{- with $dois -}}
+      {{- $doi := index . 0 | replaceRE `[.,;]+$` "" -}}
+      {{- $article = merge $article (dict "identifier" (dict "@type" "PropertyValue" "propertyID" "DOI" "value" $doi)) -}}
+    {{- end -}}
+    {{- $parts = $parts | append $article -}}
+  {{- end -}}
+{{- end -}}
+{{- if $parts -}}
+  {{- $collection := dict
+      "@context" "https://schema.org"
+      "@type" "CollectionPage"
+      "name" $page.Title
+      "url" $page.Permalink
+      "isPartOf" (dict "@type" "WebSite" "name" "FORRT" "url" "https://forrt.org")
+      "numberOfItems" (len $parts)
+      "hasPart" $parts -}}
+  <script type="application/ld+json">{{ $collection | jsonify | safeJS }}</script>
+{{- end -}}

--- a/layouts/shortcodes/summaries.html
+++ b/layouts/shortcodes/summaries.html
@@ -1,3 +1,4 @@
+{{ partial "structured-data/summaries-jsonld.html" (dict "page" .Page "deiOnly" false) }}
 {{ $summaries := site.Data.summaries }}
 {{ range $summaries }}
 

--- a/layouts/shortcodes/summaries_dei.html
+++ b/layouts/shortcodes/summaries_dei.html
@@ -1,3 +1,4 @@
+{{ partial "structured-data/summaries-jsonld.html" (dict "page" .Page "deiOnly" true) }}
 {{ $summaries := site.Data.summaries }}
 {{ range $summaries}}
 {{ if in .Title "⌺" }}


### PR DESCRIPTION
## Summary

Adds structured data (JSON-LD) across the site for richer search-engine and GenAI results, and rebuilds the author profile system, which was fundamentally broken.

SEO / GenAI optimisation advice by **Keegan Vaz** — thank you! 🙏

## Part 1 — Structured data (JSON-LD)

All built with the repo's existing `dict` + `jsonify` + `safeJS` convention (as in `clusters/seo_jsonld.html`), which JSON-escapes values safely — rather than hand-written JSON string interpolation.

| Schema | Where |
|---|---|
| `DefinedTerm` | every glossary term page (all 5 languages, correct `inLanguage`) |
| `Article` | Educators' Corner posts |
| `ScholarlyArticle` / `CollectionPage` | the two Summaries pages (196 + 34 entries) |
| `Person` | substantive author profiles |

**On DOIs:** Summaries DOIs are extracted from the stored APA reference strings via regex — never fabricated. When a reference has no DOI, the field is omitted.

**Not added — meta-description partial:** the theme's `site_head.html` already emits `description` / `og:description` / `twitter:description` (and even uses a glossary term's `definition`), so a separate partial would only duplicate the tags.

## Part 2 — Author profile page rebuild

### The problem
`content/authors/` was simultaneously a content **section** *and* the `authors` **taxonomy** (same name). Consequences:
- Any profile whose term slug matched its folder name was **suppressed** (rendered nowhere) due to the section/taxonomy path collision.
- Every profile carried a junk `authors: - Name "X"` field (a template copy-paste error) that mangled the surviving pages — they rendered at `/author/name-<slug>/` with titles literally reading `Name "..."`.
- ~250 such thin, mangled pages were in the sitemap, **hurting** SEO.

### The fix
- **Disabled** the `author` taxonomy + its permalink; author profiles now render as plain section pages at **`/authors/<slug>/`**.
- **Rewrote `layouts/authors/list.html`** to render the full profile (avatar, name, role, organization, social links, bio, real interests) plus an auto-generated list of that author's posts — and an alphabetical authors index at `/authors/`.
- **Stripped the junk `authors:` field** and added a proper `title:` across the 119 profiles.
- **Override `page_metadata_authors.html`** so bylines slugify display names and link to the new `/authors/<slug>/` URLs (previously they pointed at an empty `/author/`).
- **Noindex empty template stubs** (no bio/role/org/interests *and* no credited content) so they don't dilute search. 59 substantive profiles are indexed and carry `Person` schema; 60 empty stubs are `noindex, follow`.

### Adding authors going forward
Drop a folder under `content/authors/<username>/` with an `_index.md` (`name`, optional `role`/`bio`/`organizations`/`social`) and an `avatar` image. No taxonomy quirks.

## ⚠️ URL change
Author URLs change from `/author/name-<slug>/` → `/authors/<slug>/`. The old URLs were auto-generated and **not referenced by any internal link** (verified across content, layouts, data, static). If any are indexed/linked externally, we can add `aliases` for redirects.

## Verification
- `hugo` build is green.
- Profile pages render correctly (verified via screenshots — avatar/role/org/bio/posts).
- 119 author pages; old `/author/*` pages gone (0 in sitemap); exactly one `Person` per substantive profile (no theme duplicate).
- All JSON-LD parses as valid JSON; schemas confirmed across glossary languages, educators, and both summaries pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)