### PR TITLE
ci: make PR checks fork-friendly

### DIFF
--- a/.github/workflows/check_images.yaml
+++ b/.github/workflows/check_images.yaml
@@ -46,7 +46,9 @@ jobs:
         run: |
           python scripts/webp_conversion/check_images_in_pr.py
 
+      # Same-repo PRs: the token can write, so post/update the result as a PR comment.
       - name: Find Comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/find-comment@v4
         id: fc
         with:
@@ -55,9 +57,26 @@ jobs:
           body-includes: mage files/references
 
       - name: Create or update comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.image_check.outputs.comment }}
           edit-mode: replace
+
+      # Fork PRs: the GITHUB_TOKEN is read-only, so a PR comment would 403.
+      # Surface the same result as a job-summary report in the workflow run instead.
+      - name: Image check report (fork PR)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          REPORT: ${{ steps.image_check.outputs.comment }}
+        run: |
+          {
+            echo "## 🖼️ Image check report"
+            echo ""
+            echo "> This PR is from a fork, so the workflow cannot post a PR comment"
+            echo "> (fork runs receive a read-only token). The result is shown below."
+            echo ""
+            echo "$REPORT"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -64,8 +64,9 @@ jobs:
         run: |
           python scripts/spell_check/check_spelling.py
 
+      # Same-repo PRs: the token can write, so post/update the result as a PR comment.
       - name: Find Comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/find-comment@v4
         id: fc
         with:
@@ -74,10 +75,26 @@ jobs:
           body-includes: Spell Check
 
       - name: Create or update comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.spell_check.outputs.comment }}
           edit-mode: replace
+
+      # Fork PRs: the GITHUB_TOKEN is read-only, so a PR comment would 403.
+      # Surface the same result as a job-summary report in the workflow run instead.
+      - name: Spell check report (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          REPORT: ${{ steps.spell_check.outputs.comment }}
+        run: |
+          {
+            echo "## 📝 Spell check report"
+            echo ""
+            echo "> This PR is from a fork, so the workflow cannot post a PR comment"
+            echo "> (fork runs receive a read-only token). The result is shown below."
+            echo ""
+            echo "$REPORT"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/staging-aggregate.yaml
+++ b/.github/workflows/staging-aggregate.yaml
@@ -6,6 +6,14 @@ name: Staging Aggregate Deployment
 # Purpose: Aggregates and deploys staging changes to production
 # Triggers: PRs to main, monthly schedule, or manual dispatch
 # Features: Multi-PR aggregation, staging deployment, and force deploy option
+#
+# Fork PRs: GitHub does not pass repository secrets to runs triggered from a
+#   fork, so a fork PR cannot auto-deploy to staging (its run fails fast with a
+#   note instead of a cryptic token error). To preview a fork PR on staging, a
+#   maintainer runs this workflow manually (Actions -> Run workflow) from `main`
+#   and sets `single_pr` to the PR number. The run resolves the fork from the PR
+#   number and fetches it over its public URL, so there is no need to pick the
+#   fork branch in the dropdown.
 
 on:
   pull_request:
@@ -57,6 +65,30 @@ jobs:
       total-prs: ${{ steps.aggregate.outputs.total_prs }}
       has-prs: ${{ steps.aggregate.outputs.has_prs }}
     steps:
+      # Fork PRs can't receive secrets, so the checkout/gh steps below would fail
+      # with a cryptic "Input required and not supplied: token". Fail fast with a
+      # clear note pointing maintainers at the manual single_pr dispatch instead.
+      - name: Fork PR — staging not auto-deployed
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          PR_NUM="${{ github.event.pull_request.number }}"
+          {
+            echo "## ⏭️ Fork PR — staging not auto-deployed"
+            echo ""
+            echo "GitHub does not pass repository secrets to runs triggered from a fork,"
+            echo "so this workflow cannot auto-deploy a fork PR to staging."
+            echo ""
+            echo "**To preview this PR on staging**, a maintainer runs the *Staging Aggregate"
+            echo "Deployment* workflow manually (Actions → Run workflow) from \`main\` and sets:"
+            echo ""
+            echo "    single_pr = ${PR_NUM}"
+            echo ""
+            echo "The run pulls this fork in by PR number over its public URL — no need to"
+            echo "select the fork branch in the dropdown."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Fork PR #${PR_NUM} not auto-deployed. Maintainer: run this workflow manually with single_pr=${PR_NUM} to preview it on staging."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Why

Fork `pull_request` runs receive a **read-only** `GITHUB_TOKEN` and **no** repository secrets. Several PR-check workflows assume write access, so they fail on every fork contributor's PR:

- `check_images` / `spell-check` → the "Create or update comment" step fails with `403 Resource not accessible by integration` (the image/spell check itself runs fine; only posting the comment fails).
- `staging-aggregate` → checkout fails with the cryptic `Input required and not supplied: token` because `secrets.STAGING_GITHUB_TOKEN` resolves to empty.

(Separately observed during debugging: a one-off `401 Requires authentication` on an **internal** PR was transient GitHub auth flakiness — token had write perms — and is not addressed here.)

## What changed

**`check_images.yaml` / `spell-check.yaml`**
- Same-repo PRs: unchanged — still post/update the bot comment.
- Fork PRs: write the *same* report to the **job summary** (`$GITHUB_STEP_SUMMARY`) instead of 403ing on the comment. Report is passed via an `env:` var to avoid shell quoting/injection on the multiline body.

**`staging-aggregate.yaml`**
- Fork PRs now fail fast with a clear `::error::` + job-summary note explaining that secrets aren't available to fork runs, and pointing maintainers at the manual path: run the workflow from `main` with `single_pr=<PR#>` (the fork is resolved by PR number over its public URL — no need to select the fork branch). Replaces the cryptic token error and stops `build`/`deploy-staging` from running.
- Added a header comment documenting that fork-preview path.

## Notes

- Branch detection uses `github.event.pull_request.head.repo.full_name != github.repository`.
- Because these workflows run from each PR's own branch version, currently-open fork PRs won't pick up the new behavior until they rebase/merge past this; PRs branched afterward will.
- `link-check.yaml` also posts comments but only triggers on `schedule`/`workflow_dispatch` (never fork PRs), so it needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)