### PR TITLE
Replace FLoRA Annotator menu item with Replication Atlas link

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -283,8 +283,8 @@
   parent = "replications"
 
 [[main]]
-  name = "FLoRA Annotator"
-  url = "https://forrt.org/annotator"
+  name = "Replication Atlas"
+  url = "https://forrt.org/flora-replication-atlas/"
   weight = 62
   parent = "replications"
 


### PR DESCRIPTION
Replaces the **FLoRA Annotator** entry under the Replication Hub menu with a link to the **Replication Atlas** (https://forrt.org/flora-replication-atlas/).

- Menu label: `FLoRA Annotator` → `Replication Atlas`
- URL: `https://forrt.org/annotator` → `https://forrt.org/flora-replication-atlas/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)