### PR TITLE
Fix 404 on resources-page FORRT cluster links (#734)

### DIFF
--- a/layouts/partials/widgets/resource.html
+++ b/layouts/partials/widgets/resource.html
@@ -95,7 +95,7 @@
     {{ range $.Site.Taxonomies.FORRT_clusters.ByCount }}
     {{ if gt .Count 1 }}
     <li>
-      <a href="/tags/{{ .Name }}"> {{ .Name }} <small>({{ .Count }})</small></a>
+      <a href="{{ .Page.RelPermalink }}"> {{ .Name }} <small>({{ .Count }})</small></a>
     </li>
     {{ end }}
     {{end}}


### PR DESCRIPTION
## Problem

On [/resources/](https://forrt.org/resources/), clicking a cluster under "Number of resources per FORRT Clusters" leads to a 404 (e.g. `/tags/reproducibility%20and%20replicability%20knowledge`). Fixes #734.

## Cause

The list hard-coded its links as `/tags/{{ .Name }}` in `layouts/partials/widgets/resource.html`, which is wrong two ways:

1. **Wrong prefix** — the `tags` taxonomy permalink is `/tag/:slug/`, but these are `FORRT_clusters` terms, served at `/forrt_clusters/<slug>/`.
2. **Raw name, not slug** — `.Name` is the human-readable term (`Reproducibility and Replicability Knowledge`), which URL-encodes spaces into the 404'd path.

## Fix

Use `.Page.RelPermalink` so Hugo generates the term-page URL directly — correct by construction, and consistent with the existing cluster links in `resource_page_metadata.html`.

## Verification

Built locally with Hugo 0.158.0 extended (the version pinned in `deploy.yaml`) against the full generated resource set:

- Links now render as e.g. `/forrt_clusters/reproducibility-and-replicability-knowledge/`.
- Each term page exists and renders a paginated list of its resources — the expected "page listing the contents with this tag".
- No build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)