### PR TITLE
Add shareable per-sub-cluster links on cluster pages

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -483,6 +483,14 @@
   flex: 1;
   min-width: 0;
   line-height: 1.3;
+  /* Rendered as an <h3> for document semantics/SEO; strip heading defaults so it
+     reads as the compact accordion label (inherits .acc-header sizing/colour). */
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  font-family: inherit;
 }
 .acc-count {
   margin-left: auto;
@@ -491,6 +499,46 @@
   color: #bbb;
   flex-shrink: 0;
   white-space: nowrap;
+}
+.acc-copy-link {
+  position: relative;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  padding: 0;
+  margin-left: 0.15rem;
+  border: none;
+  background: none;
+  color: #bbb;
+  cursor: pointer;
+  border-radius: 3px;
+  opacity: 0.4;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+.acc-copy-link svg { width: 0.8rem; height: 0.8rem; }
+.acc-header:hover .acc-copy-link,
+.acc-header:focus-within .acc-copy-link { opacity: 1; }
+.acc-copy-link:hover { color: #555; background: rgba(0,0,0,0.05); }
+.acc-copy-link:focus-visible { opacity: 1; outline: 2px solid rgba(0,0,0,0.25); outline-offset: 1px; }
+.acc-copy-link.is-copied { color: #2e7d32; opacity: 1; }
+.acc-copy-link.is-copied::after {
+  content: "Copied!";
+  position: absolute;
+  bottom: calc(100% + 4px);
+  right: 0;
+  background: #2e7d32;
+  color: #fff;
+  font-size: 0.55rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.25rem 0.4rem;
+  border-radius: 3px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 5;
 }
 .acc-body {
   padding: 0 0.15rem 0.45rem 1rem;

--- a/layouts/partials/clusters/cluster_section.html
+++ b/layouts/partials/clusters/cluster_section.html
@@ -52,12 +52,17 @@
     {{ end }}
 
     {{ range $si, $sc := $cluster.sub_clusters }}
-    {{ $scid := printf "c%d-sc%d" (int $cluster.number) $si }}
+    {{/* Stable, human-readable anchor slug derived from the name (not the array index), so shared links survive reordering. Must match sidebar_nav.html. */}}
+    {{ $slug := $sc.name | lower | replaceRE "[^a-z0-9]+" "-" | replaceRE "^-+|-+$" "" }}
+    {{ $scid := printf "c%d-%s" (int $cluster.number) $slug }}
     <div class="acc-section" id="{{ $scid }}">
       <div class="acc-header" role="button" tabindex="0">
         <span class="acc-chevron">&#9656;</span>
-        <span class="acc-label">{{ $sc.name }}</span>
+        <h3 class="acc-label">{{ $sc.name }}</h3>
         <span class="acc-count"><span class="acc-count-match">{{ len $sc.publications }}</span> / {{ len $sc.publications }}</span>
+        <button type="button" class="acc-copy-link" data-anchor="{{ $scid }}" aria-label="Copy link to this sub-cluster" title="Copy link to this sub-cluster">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true"><path d="M6.5 9.5l3-3M7 4.5l1-1a3 3 0 014.25 4.25l-1 1M9 11.5l-1 1a3 3 0 01-4.25-4.25l1-1"/></svg>
+        </button>
       </div>
       <div class="acc-body acc-collapsed">
 

--- a/layouts/partials/clusters/sidebar_nav.html
+++ b/layouts/partials/clusters/sidebar_nav.html
@@ -42,7 +42,9 @@
           </li>
           {{ end }}
           {{ range $si, $sc := $cluster.sub_clusters }}
-          {{ $scid := printf "c%d-sc%d" (int $cluster.number) $si }}
+          {{/* Slug must match cluster_section.html so the anchor target exists. */}}
+          {{ $slug := $sc.name | lower | replaceRE "[^a-z0-9]+" "-" | replaceRE "^-+|-+$" "" }}
+          {{ $scid := printf "c%d-%s" (int $cluster.number) $slug }}
           {{ $subHref := printf "#%s" $cid }}
           {{ if and (eq $link_mode "subpath") (not $isActive) }}
             {{ $subHref = printf "/clusters/cluster-%d/#%s" (int $cluster.number) $scid | relURL }}

--- a/static/js/clusters-page.js
+++ b/static/js/clusters-page.js
@@ -440,7 +440,7 @@
     /* e.g. /clusters/cluster-2/#c2-sc1 or #c2-featured — scroll to matching section */
     function applyClusterUrlHash() {
       var raw = window.location.hash.replace(/^#/, '');
-      if (!raw || !/^c\d+-(sc\d+|featured)$/.test(raw)) return;
+      if (!raw || !/^c\d+-[a-z0-9-]+$/.test(raw)) return;
       var target = document.getElementById(raw);
       if (!target) return;
       /* Expand accordion section if collapsed */
@@ -460,6 +460,50 @@
     }
     applyClusterUrlHash();
     window.addEventListener('hashchange', applyClusterUrlHash);
+
+    /* Per-sub-cluster "copy link" buttons: copy a shareable URL to the section. */
+    function copyTextToClipboard(text) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text);
+      }
+      return new Promise(function (resolve, reject) {
+        try {
+          var ta = document.createElement('textarea');
+          ta.value = text;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'absolute';
+          ta.style.left = '-9999px';
+          document.body.appendChild(ta);
+          ta.select();
+          var ok = document.execCommand('copy');
+          document.body.removeChild(ta);
+          ok ? resolve() : reject();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }
+
+    root.addEventListener('click', function (e) {
+      var btn = e.target.closest('.acc-copy-link');
+      if (!btn) return;
+      /* Don't let the click bubble to the accordion header toggle. */
+      e.preventDefault();
+      e.stopPropagation();
+      var anchor = btn.getAttribute('data-anchor');
+      if (!anchor) return;
+      var url = window.location.origin + window.location.pathname + window.location.search + '#' + anchor;
+      /* Reflect the anchor in the address bar without re-scrolling (no hashchange). */
+      try { window.history.replaceState(null, '', '#' + anchor); } catch (err) {}
+      copyTextToClipboard(url).then(function () {
+        btn.classList.add('is-copied');
+        if (btn._copiedTimer) clearTimeout(btn._copiedTimer);
+        btn._copiedTimer = setTimeout(function () { btn.classList.remove('is-copied'); }, 1600);
+      }).catch(function () {
+        /* Clipboard blocked (e.g. insecure context): prompt the user with the URL. */
+        window.prompt('Copy this link:', url);
+      });
+    });
 
     /* (Tab click handler removed — all sub-clusters are now visible sections) */
 

--- a/static/js/featured-resources.js
+++ b/static/js/featured-resources.js
@@ -636,6 +636,8 @@
 
     // Click handler for accordion headers
     document.addEventListener('click', function (e) {
+      // Controls embedded in the header (e.g. copy-link) handle their own clicks.
+      if (e.target.closest('.acc-copy-link')) return;
       var header = e.target.closest('.acc-header');
       if (header) { toggleSection(header); return; }
       var toggleBtn = e.target.closest('.acc-toggle-all');
@@ -645,6 +647,7 @@
     // Keyboard: Enter/Space on header
     document.addEventListener('keydown', function (e) {
       if (e.key !== 'Enter' && e.key !== ' ') return;
+      if (e.target.closest('.acc-copy-link')) return;
       var header = e.target.closest('.acc-header');
       if (!header) return;
       e.preventDefault();


### PR DESCRIPTION
Closes #798

## What
Each sub-cluster on a cluster page now has its own shareable link. Hovering a sub-cluster header reveals a small copy-link button that copies a stable URL like `https://forrt.org/clusters/cluster-9/#c9-racism-in-science`. Opening such a link auto-expands that sub-cluster and scrolls to it.

## How
- **Stable, human-readable anchors.** Anchor ids are now derived from the sub-cluster name (`c9-racism-in-science`) instead of its array index (`c9-sc12`). This means shared links survive reordering/insertion of sub-clusters instead of silently pointing at the wrong content. Verified: 0 slug collisions across all 11 clusters.
- **Copy-link button** per sub-cluster header: copies the absolute URL, shows a "Copied!" tooltip, updates the address bar via `history.replaceState` (no jump), and is guarded so it does not toggle the accordion (click + keyboard).
- **`<h3>` headings.** Sub-cluster labels are promoted from `<span>` to `<h3>` (nested under the cluster `<h2>`) for document semantics and SEO section eligibility. `<h3>` browser defaults are reset in CSS so the compact accordion header renders identically.

## Verification
Built with Hugo 0.158.0 and tested in a headless browser:
- Slug ids render correctly; all in-page sidebar links resolve to existing section ids.
- Copy button copies the full URL, shows the tooltip, updates the hash, and does not collapse/expand the section.
- Fresh-loading a copied link reliably expands the target sub-cluster and scrolls it below the sticky nav.
- Header layout, font, and spacing unchanged after the `<h3>` promotion (computed styles match the previous `<span>`).

## Note on SEO scope
This deliberately uses anchors rather than ~190 standalone per-sub-cluster pages. Fragments don't rank independently, and auto-generated sub-cluster pages would be thin slices of the already-indexed cluster hub (duplicate-content risk). The `<h3>` promotion is the low-risk SEO/semantics win. Real per-sub-cluster landing pages, if ever wanted, are better pursued selectively with genuine editorial content as a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)