### PR TITLE
Add three large-scale replication projects to LSRP list (#729)

### DIFF
--- a/content/replication-hub/large-scale-replication-projects/index.md
+++ b/content/replication-hub/large-scale-replication-projects/index.md
@@ -295,5 +295,41 @@ Here you can find a list of completed and ongoing projects that summarize replic
    <td>No
    </td>
   </tr>
+  <tr>
+   <td>Experimental Economics Replication Project (EERP; Camerer et al. 2016)
+   </td>
+   <td>Experimental Economics
+   </td>
+   <td><a href="https://doi.org/10.1126/science.aaf0918">https://doi.org/10.1126/science.aaf0918</a>
+   </td>
+   <td>Yes
+   </td>
+   <td>No
+   </td>
+  </tr>
+  <tr>
+   <td>Mechanical Turk Replication Project (MTRP; Holzmeister et al. 2024)
+   </td>
+   <td>Social Sciences (online experiments)
+   </td>
+   <td><a href="https://doi.org/10.1038/s41562-024-02062-9">https://doi.org/10.1038/s41562-024-02062-9</a>
+   </td>
+   <td>Yes
+   </td>
+   <td>No
+   </td>
+  </tr>
+  <tr>
+   <td>Huber et al. (forthcoming)
+   </td>
+   <td>Experimental Economics (asset markets)
+   </td>
+   <td><a href="https://dx.doi.org/10.2139/ssrn.5048949">https://dx.doi.org/10.2139/ssrn.5048949</a>
+   </td>
+   <td>No
+   </td>
+   <td>No
+   </td>
+  </tr>
 </table>
 


### PR DESCRIPTION
Closes #729.

Adds three studies to the [List of Large-Scale Replication Projects](https://forrtproject.github.io/replication-hub/large-scale-replication-projects/) table:

| Project | Topic | Link | FReD | Ongoing |
|---|---|---|---|---|
| Experimental Economics Replication Project (EERP; Camerer et al. 2016) | Experimental Economics | https://doi.org/10.1126/science.aaf0918 | Yes | No |
| Mechanical Turk Replication Project (MTRP; Holzmeister et al. 2024) | Social Sciences (online experiments) | https://doi.org/10.1038/s41562-024-02062-9 | Yes | No |
| Huber et al. (forthcoming) | Experimental Economics (asset markets) | https://dx.doi.org/10.2139/ssrn.5048949 | No | No |

Titles, journals, DOIs and author lists verified against Crossref/publisher sources. FReD-inclusion values confirmed with the maintainer (EERP and MTRP: Yes; Huber: No).

The issue also notes a possible broader revision of the table based on Rachel Heyard's review — that is out of scope here and left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)