### PR TITLE
Add metadata to app pages and stop indexing the redirect stubs (#710)

### DIFF
--- a/static/annotator/index.html
+++ b/static/annotator/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FLoRA Annotator</title>
+    <meta name="description" content="Look up replication and reproduction attempts for any reference, drawn from the FORRT Library of Reproduction and Replication Attempts (FLoRA).">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="FORRT">
+    <meta property="og:title" content="FLoRA Annotator | FORRT">
+    <meta property="og:description" content="Look up replication and reproduction attempts for any reference, drawn from the FORRT Library of Reproduction and Replication Attempts (FLoRA).">
+    <meta property="og:url" content="https://forrt.org/annotator/">
+    <meta property="og:image" content="https://forrt.org/img/FORRTbanner.webp">
+    <meta property="og:image:width" content="4000">
+    <meta property="og:image:height" content="2250">
+    <meta property="og:image:alt" content="FORRT - Framework for Open and Reproducible Research Training">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="FLoRA Annotator | FORRT">
+    <meta name="twitter:description" content="Look up replication and reproduction attempts for any reference, drawn from the FORRT Library of Reproduction and Replication Attempts (FLoRA).">
+    <meta name="twitter:image" content="https://forrt.org/img/FORRTbanner.webp">
     <link rel="icon" href="/img/image.webp" type="image/webp">
     <link rel="canonical" href="/annotator/">
 </head>

--- a/static/apps/awop_app.html
+++ b/static/apps/awop_app.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex">
   <title>Redirecting to Academic Wheel of Privilege (AWoP)</title>
   <meta http-equiv="refresh" content="0; url=/awop_app/">
   <link rel="canonical" href="/awop_app/">

--- a/static/apps/flora_annotator.html
+++ b/static/apps/flora_annotator.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex">
   <title>Redirecting to FLoRA Annotator</title>
   <meta http-equiv="refresh" content="0; url=/annotator/">
   <link rel="canonical" href="/annotator/">

--- a/static/apps/fred_annotator.html
+++ b/static/apps/fred_annotator.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex">
   <title>Redirecting to FLoRA Annotator</title>
   <meta http-equiv="refresh" content="0; url=/annotator/">
   <link rel="canonical" href="/annotator/">

--- a/static/apps/fred_explorer.html
+++ b/static/apps/fred_explorer.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex">
   <title>Redirecting to FReD Explorer</title>
   <meta http-equiv="refresh" content="0; url=/explorer/">
   <link rel="canonical" href="/explorer/">

--- a/static/apps/open_research_games_portal.html
+++ b/static/apps/open_research_games_portal.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex">
   <title>Redirecting to Open Research Games Portal</title>
   <meta http-equiv="refresh" content="0; url=/open-research-games-portal/">
   <link rel="canonical" href="/open-research-games-portal/">

--- a/static/apps/os_map.html
+++ b/static/apps/os_map.html
@@ -3,7 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FReD Explorer</title>
+    <title>Mapping Open Science Communities</title>
+    <meta name="description" content="An interactive map of open-science communities and initiatives across disciplines, from FORRT.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="FORRT">
+    <meta property="og:title" content="Mapping Open Science Communities | FORRT">
+    <meta property="og:description" content="An interactive map of open-science communities and initiatives across disciplines, from FORRT.">
+    <meta property="og:url" content="https://forrt.org/apps/os_map.html">
+    <meta property="og:image" content="https://forrt.org/img/FORRTbanner.webp">
+    <meta property="og:image:width" content="4000">
+    <meta property="og:image:height" content="2250">
+    <meta property="og:image:alt" content="FORRT - Framework for Open and Reproducible Research Training">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mapping Open Science Communities | FORRT">
+    <meta name="twitter:description" content="An interactive map of open-science communities and initiatives across disciplines, from FORRT.">
+    <meta name="twitter:image" content="https://forrt.org/img/FORRTbanner.webp">
 </head>
 <body>
   <style>

--- a/static/apps/re-searchterms.html
+++ b/static/apps/re-searchterms.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Re-SearchTerms</title>
+    <meta name="description" content="Explore alternative and competing definitions of open-science and research terms with the FORRT Re-SearchTerms app.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="FORRT">
+    <meta property="og:title" content="Re-SearchTerms | FORRT">
+    <meta property="og:description" content="Explore alternative and competing definitions of open-science and research terms with the FORRT Re-SearchTerms app.">
+    <meta property="og:url" content="https://forrt.org/apps/re-searchterms.html">
+    <meta property="og:image" content="https://forrt.org/img/FORRTbanner.webp">
+    <meta property="og:image:width" content="4000">
+    <meta property="og:image:height" content="2250">
+    <meta property="og:image:alt" content="FORRT - Framework for Open and Reproducible Research Training">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Re-SearchTerms | FORRT">
+    <meta name="twitter:description" content="Explore alternative and competing definitions of open-science and research terms with the FORRT Re-SearchTerms app.">
+    <meta name="twitter:image" content="https://forrt.org/img/FORRTbanner.webp">
 </head>
 <body>
   <style>

--- a/static/awop_app/index.html
+++ b/static/awop_app/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Academic Wheel of Privilege (AWoP)</title>
+    <meta name="description" content="An equity-based tool that helps research teams weigh privilege across socio-cultural identities to make authorship order fairer and more transparent.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="FORRT">
+    <meta property="og:title" content="Academic Wheel of Privilege (AWoP) | FORRT">
+    <meta property="og:description" content="An equity-based tool that helps research teams weigh privilege across socio-cultural identities to make authorship order fairer and more transparent.">
+    <meta property="og:url" content="https://forrt.org/awop_app/">
+    <meta property="og:image" content="https://forrt.org/img/FORRTbanner.webp">
+    <meta property="og:image:width" content="4000">
+    <meta property="og:image:height" content="2250">
+    <meta property="og:image:alt" content="FORRT - Framework for Open and Reproducible Research Training">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Academic Wheel of Privilege (AWoP) | FORRT">
+    <meta name="twitter:description" content="An equity-based tool that helps research teams weigh privilege across socio-cultural identities to make authorship order fairer and more transparent.">
+    <meta name="twitter:image" content="https://forrt.org/img/FORRTbanner.webp">
     <link rel="icon" href="/img/image.webp" type="image/webp">
     <link rel="canonical" href="/awop_app/">
 </head>

--- a/static/explorer/index.html
+++ b/static/explorer/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FReD Explorer</title>
+    <meta name="description" content="Browse and filter the FORRT Replication Database (FReD) to explore replication studies and their outcomes.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="FORRT">
+    <meta property="og:title" content="FReD Explorer | FORRT">
+    <meta property="og:description" content="Browse and filter the FORRT Replication Database (FReD) to explore replication studies and their outcomes.">
+    <meta property="og:url" content="https://forrt.org/explorer/">
+    <meta property="og:image" content="https://forrt.org/img/FORRTbanner.webp">
+    <meta property="og:image:width" content="4000">
+    <meta property="og:image:height" content="2250">
+    <meta property="og:image:alt" content="FORRT - Framework for Open and Reproducible Research Training">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="FReD Explorer | FORRT">
+    <meta name="twitter:description" content="Browse and filter the FORRT Replication Database (FReD) to explore replication studies and their outcomes.">
+    <meta name="twitter:image" content="https://forrt.org/img/FORRTbanner.webp">
     <link rel="icon" href="/img/image.webp" type="image/webp">
     <link rel="canonical" href="/explorer/">
 </head>

--- a/static/open-research-games-portal/index.html
+++ b/static/open-research-games-portal/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Open Research Games Portal</title>
+    <meta name="description" content="A crowdsourced, pedagogically informed database of games and interactive activities for teaching open and reproducible research practices.">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="FORRT">
+    <meta property="og:title" content="Open Research Games Portal | FORRT">
+    <meta property="og:description" content="A crowdsourced, pedagogically informed database of games and interactive activities for teaching open and reproducible research practices.">
+    <meta property="og:url" content="https://forrt.org/open-research-games-portal/">
+    <meta property="og:image" content="https://forrt.org/img/FORRTbanner.webp">
+    <meta property="og:image:width" content="4000">
+    <meta property="og:image:height" content="2250">
+    <meta property="og:image:alt" content="FORRT - Framework for Open and Reproducible Research Training">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Open Research Games Portal | FORRT">
+    <meta name="twitter:description" content="A crowdsourced, pedagogically informed database of games and interactive activities for teaching open and reproducible research practices.">
+    <meta name="twitter:image" content="https://forrt.org/img/FORRTbanner.webp">
     <link rel="icon" href="/img/headers/orgp.webp" type="image/webp">
     <link rel="canonical" href="/open-research-games-portal/">
 </head>


### PR DESCRIPTION
Closes #710.

The static iframe and redirect pages under `static/` are served verbatim and bypass Hugo's `site_head.html`, so they never got the `description` / Open Graph / Twitter-card tags that normal pages have. This adds them, and stops the redirect stubs from being indexed.

## App pages — added social/SEO metadata
`description` + Open Graph + Twitter-card tags on each, using the site's default share image (`/img/FORRTbanner.webp`), so links render proper previews when shared:

| Page | Description |
|---|---|
| `awop_app/` | An equity-based tool that helps research teams weigh privilege across socio-cultural identities to make authorship order fairer and more transparent. |
| `annotator/` | Look up replication and reproduction attempts for any reference, drawn from the FORRT Library of Reproduction and Replication Attempts (FLoRA). |
| `explorer/` | Browse and filter the FORRT Replication Database (FReD) to explore replication studies and their outcomes. |
| `open-research-games-portal/` | A crowdsourced, pedagogically informed database of games and interactive activities for teaching open and reproducible research practices. |
| `apps/re-searchterms.html` | Explore alternative and competing definitions of open-science and research terms with the FORRT Re-SearchTerms app. |
| `apps/os_map.html` | An interactive map of open-science communities and initiatives across disciplines, from FORRT. |

Descriptions were authored from the corresponding content pages — happy to adjust wording.

## Redirect stubs — `noindex`
Added `<meta name="robots" content="noindex">` to the legacy redirect stubs so the bare "Redirecting to…" pages stop appearing in search results (they already carried a `canonical` to the real page): `apps/awop_app.html`, `apps/flora_annotator.html`, `apps/fred_annotator.html`, `apps/fred_explorer.html`, `apps/open_research_games_portal.html`.

## Also in this PR
- **`apps/os_map.html` title fix:** its `<title>` was mislabeled "FReD Explorer" but it embeds the OS-mapping app — corrected.

## Noted separately (not fixed here)
- **`apps/os_map.html` looks orphaned** — nothing links to it (the community map embeds `forrt-map.html` instead).
- **Re-SearchTerms routing mismatch** — the glossary links `/re-searchterms/`, but the file is served at `/apps/re-searchterms.html` and `/re-searchterms/` appears to 404. `og:url` here points at the actual served path; the broken glossary link is a separate follow-up.
- **`forrt-map.html`** (generated Leaflet map) left untouched — it's an embed fragment inside the community-map page (which already has metadata), and edits would be lost on regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)