### PR TITLE
Search all resource fields, untruncated (closes #286)

### DIFF
--- a/layouts/partials/resource_li_card.html
+++ b/layouts/partials/resource_li_card.html
@@ -19,7 +19,24 @@
 {{ $resource := ($item.Resources.ByType "image").GetMatch "*featured*" }}
 {{ $js_tag_classes := delimit (apply (apply $item.Params.FORRT_clusters "replace" "." " " "-") "printf" "js-id-%s" ".") " " }}
 
-<div class="project-card project-item isotope-item py-1 {{ $js_tag_classes | safeHTMLAttr }}">
+{{/* Build a hidden, label-free search index spanning all fields (issue #286). The
+     displayed card truncates the abstract and omits several fields; searching this
+     blob instead of the rendered text lets partial matches hit every field. */}}
+{{ $search := delimit (slice
+  ($item.Title | plainify)
+  ($item.Params.Abstract | default "" | markdownify | plainify)
+  (delimit $item.Params.Creators " ")
+  (delimit $item.Params.Material_Type " ")
+  (delimit $item.Params.Primary_User " ")
+  (delimit $item.Params.Subject_Areas " ")
+  (delimit $item.Params.Tags " ")
+  (delimit $item.Params.Education_Level " ")
+  (delimit $item.Params.Language " ")
+  ($item.Params.Conditions_of_Use | default "")
+  (delimit $item.Params.FORRT_clusters " ")
+) " " }}
+
+<div class="project-card project-item isotope-item py-1 {{ $js_tag_classes | safeHTMLAttr }}" data-search="{{ lower $search }}">
   <div class="card">
     {{ with $resource }}
     {{ $image := .Resize (printf "550x q90 %s") }}

--- a/themes/academic/assets/js/academic.js
+++ b/themes/academic/assets/js/academic.js
@@ -663,7 +663,9 @@
             let filterMatch = projectFilter ? $this.is(projectFilter) : true;
             if (!filterMatch) return false;
             if (!projectSearchTerms) return true;
-            let text = $this.text().replace(/-/g, '');
+            // Search the hidden data-search index (all fields, untruncated) when present,
+            // falling back to the rendered card text for widgets that don't provide it.
+            let text = ($this.attr('data-search') || $this.text()).replace(/-/g, '');
             return projectSearchTerms.every(function (re) { return re.test(text); });
           }
         });


### PR DESCRIPTION
Closes #286.

## Background

Issue #286 asked for partial matches and for all fields (e.g. authors) to be searchable on the curated resources page. PR #737 already delivered partial/prefix matching, AND-across-words logic, and put authors/type/primary user/subject areas/tags into the card text.

One real gap remained: the search ran against each card's **rendered** text, which truncates the abstract to 135 characters and never renders `education_level`, `language`, or `conditions_of_use`. A word in the tail of a long abstract (e.g. "sardines" in *A 21 word solution*) returned **0 results**.

## Change

- **`layouts/partials/resource_li_card.html`** — add a hidden, label-free `data-search` attribute on each resource card holding the **full untruncated abstract plus every field** (title, abstract, creators, material type, primary user, subject areas, tags, education level, language, conditions of use, FORRT clusters).
- **`themes/academic/assets/js/academic.js`** — point the Isotope text filter at `data-search` when present, falling back to the rendered card text for other widgets (so nothing else changes).

Being label-free also removes a latent false positive — searching "author" no longer matches every card.

## Verification

Built the site (1488 resources) and tested both via the exact JS filter predicate over the built HTML and via a live headless browser against a local Hugo build; counts and visible cards matched.

| query | meaning | before | after |
|---|---|---|---|
| `replicat` | partial word | works | 475 |
| `Lakens` | author surname | works | 27 (incl. Welch t-test) |
| `sardines` | tail of a long abstract | 0 ❌ | 1 ✅ (*A 21 word solution*) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)