### PR TITLE
fix: Deprecates and windows filename restrictions 

### DIFF
--- a/content/curated_resources/guideline-for-reporting-systematic-revie.md
+++ b/content/curated_resources/guideline-for-reporting-systematic-revie.md
@@ -57,7 +57,7 @@
         "Outcome measurement instrument",
         "PRISMA",
         "Reporting guideline",
-        "Systematic reviews."
+        "Systematic reviews"
     ],
     "forrt_clusters_new": "Replication and meta-research, Replication Crisis and Credibility Revolution",
     "forrt_sub_clusters": "Meta-analyses, Proposed science improvement initiatives on statistics, measurement, teaching, data sharing, code sharing, pre-registration, & replication",

--- a/content/curated_resources/interpreting-effect-sizes-and-confidence.md
+++ b/content/curated_resources/interpreting-effect-sizes-and-confidence.md
@@ -27,7 +27,7 @@
         "Conceptual and Statistical Knowledge"
     ],
     "tags": [
-        "Statistics; Effect Sizes; Confidence Intervals; Data Analysis; Data Visualization; Data Interpretation."
+        "Statistics; Effect Sizes; Confidence Intervals; Data Analysis; Data Visualization; Data Interpretation"
     ],
     "forrt_clusters_new": "Conceptual and Statistical Knowledge",
     "forrt_sub_clusters": "Effect sizes, statistical power, simulations, & confidence intervals.",

--- a/content/curated_resources/on-the-use-and-misuses-of-preregistratio.md
+++ b/content/curated_resources/on-the-use-and-misuses-of-preregistratio.md
@@ -37,7 +37,7 @@
         "Falsification",
         "Severity",
         "Open Science",
-        "Methodological Reform."
+        "Methodological Reform"
     ],
     "forrt_clusters_new": "Pre-analysis Planning, Replication Crisis and Credibility Revolution",
     "forrt_sub_clusters": "Ongoing debates (e.g., incentives for and against open science practices), Understanding the types of preregistration and writing one.",

--- a/content/curated_resources/revisiting-the-replication-crisis-withou.md
+++ b/content/curated_resources/revisiting-the-replication-crisis-withou.md
@@ -38,7 +38,7 @@
         "Metascience",
         "Replication",
         "Reproducibility",
-        "Statistics."
+        "Statistics"
     ],
     "forrt_clusters_new": "Replication Crisis and Credibility Revolution, Replication and meta-research",
     "forrt_sub_clusters": "Meta-research, Ongoing debates (e.g., incentives for and against open science practices)",

--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-_build:
+build:
   render: never
   list: never
 ---

--- a/content/nowherelab/phd-survival-guide.md
+++ b/content/nowherelab/phd-survival-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Nowhere Lab PhD Survival Guide
 date: 2026-04-28
-_build:
+build:
   list: never
 ---
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-{{- $language_code := site.LanguageCode | default "en-us" -}}
-<html lang="{{$language_code}}" {{ if in site.Data.i18n.rtl.rtl $language_code }}dir="rtl"{{end}}>
+{{- $language_code := site.Language.Locale | default "en-us" -}}
+<html lang="{{$language_code}}" {{ if in hugo.Data.i18n.rtl.rtl $language_code }}dir="rtl"{{end}}>
 
 {{ partial "site_head" . }}
 

--- a/layouts/clusters/cluster.html
+++ b/layouts/clusters/cluster.html
@@ -18,7 +18,7 @@
 */}}
 {{ define "main" }}
 {{ $n := int .Params.cluster_number }}
-{{ $data := site.Data.clusters_v4 }}
+{{ $data := hugo.Data.clusters_v4 }}
 {{ $cluster := false }}
 {{ if $data }}
   {{ range $data.clusters }}

--- a/layouts/partials/clusters/all_clusters.html
+++ b/layouts/partials/clusters/all_clusters.html
@@ -1,5 +1,5 @@
 {{/* all_clusters.html - Partial to display all clusters from data */}}
-{{ $data := site.Data.clusters_v4 }}
+{{ $data := hugo.Data.clusters_v4 }}
 {{ if not $data }}
   <div class="alert alert-warning">
     <strong>Data Error:</strong> clusters_v4.json data not found. Run <code>python3 scripts/parse_clusters_to_sheet.py --export-json</code>.

--- a/layouts/partials/clusters/cluster_section.html
+++ b/layouts/partials/clusters/cluster_section.html
@@ -10,7 +10,7 @@
 {{ $featuredEnabled := site.Params.enable_featured_resources }}
 {{ $featuredData := false }}
 {{ if $featuredEnabled }}
-  {{ with site.Data.featured_resources }}
+  {{ with hugo.Data.featured_resources }}
     {{ $key := printf "%d" (int $cluster.number) }}
     {{ with index .clusters $key }}
       {{ $featuredData = . }}
@@ -71,7 +71,7 @@
         {{ end }}
 
         {{ if $sc.publications }}
-        {{ $pubCards := site.Data.pub_cards }}
+        {{ $pubCards := hugo.Data.pub_cards }}
         <div class="fr-cards-list">
           {{ range $pi, $pub := $sc.publications }}
           {{ $card := false }}

--- a/layouts/partials/clusters/cluster_seo_jsonld.html
+++ b/layouts/partials/clusters/cluster_seo_jsonld.html
@@ -14,7 +14,7 @@
 
 {{ $hubURL := "clusters/" | absURL }}
 
-{{ $webpage := dict "@type" "WebPage" "@id" (printf "%s#webpage" $p.Permalink) "url" $p.Permalink "name" $p.Title "description" $summary "inLanguage" (site.LanguageCode | default "en-US") }}
+{{ $webpage := dict "@type" "WebPage" "@id" (printf "%s#webpage" $p.Permalink) "url" $p.Permalink "name" $p.Title "description" $summary "inLanguage" (site.Language.Locale | default "en-US") }}
 {{ if and $p.Params.sharing_image_resource ($p.Resources.GetMatch $p.Params.sharing_image_resource) }}
   {{ $pimg := $p.Resources.GetMatch $p.Params.sharing_image_resource }}
   {{ $webpage = merge $webpage (dict "primaryImageOfPage" (dict "@type" "ImageObject" "url" $pimg.Permalink)) }}

--- a/layouts/partials/clusters/clusters_controls.html
+++ b/layouts/partials/clusters/clusters_controls.html
@@ -7,7 +7,7 @@
       <input type="text" id="clusters-inline-search-input" class="fr-search-input"
              placeholder="Search resources..." aria-label="Search clusters and resources" autocomplete="off" spellcheck="false">
     </div>
-    {{ $tags := site.Data.filter_tags }}
+    {{ $tags := hugo.Data.filter_tags }}
     <div class="fr-filter-group">
       <span class="fr-filter-label">Focus</span>
       <div class="fr-filter-tags" data-filter="focus" id="fr-global-focus-tags">

--- a/layouts/partials/clusters/featured_global.html
+++ b/layouts/partials/clusters/featured_global.html
@@ -46,15 +46,15 @@
 </div>
 
 {{/* Inject featured data, pub card lookup, and focus order as JSON for JS */}}
-{{ $featured := site.Data.featured_resources }}
+{{ $featured := hugo.Data.featured_resources }}
 {{ if $featured }}
 <script>window.FORRT_FEATURED = {{ $featured | jsonify | safeJS }};</script>
 {{ end }}
-{{ $pubCards := site.Data.pub_cards }}
+{{ $pubCards := hugo.Data.pub_cards }}
 {{ if $pubCards }}
 <script>window.FORRT_PUB_CARDS = {{ $pubCards | jsonify | safeJS }};</script>
 {{ end }}
-{{ $filterTags := site.Data.filter_tags }}
+{{ $filterTags := hugo.Data.filter_tags }}
 {{ if $filterTags }}
 <script>window.FORRT_FOCUS_ORDER = {{ $filterTags.focus | jsonify | safeJS }};</script>
 {{ end }}

--- a/layouts/partials/clusters/seo_jsonld.html
+++ b/layouts/partials/clusters/seo_jsonld.html
@@ -1,5 +1,5 @@
 {{/* Structured data: WebPage + ItemList of all clusters for search engines */}}
-{{ $data := site.Data.clusters_v4 }}
+{{ $data := hugo.Data.clusters_v4 }}
 {{ if not $data }}{{ return }}{{ end }}
 
 {{ $summary := .Params.summary | default .Description | default "" }}
@@ -22,7 +22,7 @@
   {{ $elements = $elements | append $item }}
 {{ end }}
 
-{{ $webpage := dict "@type" "WebPage" "@id" (printf "%s#webpage" .Permalink) "url" .Permalink "name" .Title "description" $summary "inLanguage" (site.LanguageCode | default "en-US") }}
+{{ $webpage := dict "@type" "WebPage" "@id" (printf "%s#webpage" .Permalink) "url" .Permalink "name" .Title "description" $summary "inLanguage" (site.Language.Locale | default "en-US") }}
 {{ if and .Params.sharing_image_resource (.Resources.GetMatch .Params.sharing_image_resource) }}
   {{ $pimg := .Resources.GetMatch .Params.sharing_image_resource }}
   {{ $webpage = merge $webpage (dict "primaryImageOfPage" (dict "@type" "ImageObject" "url" $pimg.Permalink)) }}

--- a/layouts/partials/clusters/sidebar_nav.html
+++ b/layouts/partials/clusters/sidebar_nav.html
@@ -24,7 +24,7 @@
           {{ $featEnabled := site.Params.enable_featured_resources }}
           {{ $hasFeat := false }}
           {{ if $featEnabled }}
-            {{ with site.Data.featured_resources }}
+            {{ with hugo.Data.featured_resources }}
               {{ $ck := printf "%d" (int $cluster.number) }}
               {{ with index .clusters $ck }}{{ $hasFeat = true }}{{ end }}
             {{ end }}

--- a/layouts/partials/functions/tags.html
+++ b/layouts/partials/functions/tags.html
@@ -1,6 +1,6 @@
 {{/* Get Publication Types */}}
 {{ $cluster_types := slice }}
-{{ range site.Data.clusters.types }}
+{{ range hugo.Data.clusters.types }}
   {{ $cluster_types = $cluster_types | append (i18n . | default "Uncategorized") }}
 {{ end }}
 {{ return $cluster_types }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -149,15 +149,15 @@
       <li class="nav-item dropdown i18n-dropdown">
         <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
           <i class="fas fa-globe mr-1" aria-hidden="true"></i><span class="d-none d-xl-inline">{{ index
-            site.Data.i18n.languages .Lang }}</span>
+            hugo.Data.i18n.languages .Lang }}</span>
         </a>
         <div class="dropdown-menu">
           <div class="dropdown-item i18n-active font-weight-bold">
-            <span>{{ index site.Data.i18n.languages .Lang }}</span>
+            <span>{{ index hugo.Data.i18n.languages .Lang }}</span>
           </div>
           {{ range .Translations }}
           <a class="dropdown-item" href="{{ .Permalink }}">
-            <span>{{ index site.Data.i18n.languages .Lang }}</span>
+            <span>{{ index hugo.Data.i18n.languages .Lang }}</span>
           </a>
           {{ end }}
         </div>

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
+  <meta name="generator" content="Source Themes Academic {{ hugo.Data.academic.version }}">
 
   {{ range .Resources.Match "htmlwidgets_libs/**/*.js" }}
   <script src="{{ .RelPermalink }}"></script>
@@ -67,11 +67,11 @@
   {{ range .Translations }}
   <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
   {{ end }}
-  <link rel="alternate" hreflang="{{ site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}">
+  <link rel="alternate" hreflang="{{ site.Language.Locale | default "en-us" }}" href="{{ .Permalink }}">
 
   {{ partial "functions/parse_theme" . }}
-  {{ $css := site.Data.assets.css }}
-  {{ $js := site.Data.assets.js }}
+  {{ $css := hugo.Data.assets.css }}
+  {{ $js := hugo.Data.assets.js }}
   {{ if ne ($scr.Get "primary") "#fff" }}
   <meta name="theme-color" content="{{ $scr.Get "primary" }}">
   {{ end }}
@@ -130,7 +130,7 @@
     {{ end }}
 
     {{/* Load async scripts. */}}
-    {{ range $k, $v := site.Data.assets.js }}{{/* TODO: investigate why `where ... "async" true` does not work. */}}
+    {{ range $k, $v := hugo.Data.assets.js }}{{/* TODO: investigate why `where ... "async" true` does not work. */}}
       {{ $load := $v.async }}
 
       {{/* Only load MathJax if required. */}}
@@ -158,7 +158,7 @@
     {{ end }}
   {{ end }}
 
-  {{ $css_comment := printf "/*!* Source Themes Academic v%s (https://sourcethemes.com/academic/) */\n" site.Data.academic.version }}
+  {{ $css_comment := printf "/*!* Source Themes Academic v%s (https://sourcethemes.com/academic/) */\n" hugo.Data.academic.version }}
   {{ $css_bundle_head := $css_comment | resources.FromString "css/bundle-head.css" }}
   {{ $css_options := dict "targetPath" "css/academic.css" }}
   {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") -}}
@@ -254,7 +254,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{{ $og_image }}">
   {{- end -}}
-  <meta property="og:locale" content="{{ site.LanguageCode | default "en-us" }}">
+  <meta property="og:locale" content="{{ site.Language.Locale | default "en-us" }}">
   {{ if .IsPage }}
     {{ if not .PublishDate.IsZero }}
       <meta property="article:published_time" content="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">

--- a/layouts/partials/structured-data/summaries-jsonld.html
+++ b/layouts/partials/structured-data/summaries-jsonld.html
@@ -12,7 +12,7 @@
 {{- $page := .page -}}
 {{- $deiOnly := .deiOnly -}}
 {{- $parts := slice -}}
-{{- range $s := site.Data.summaries -}}
+{{- range $s := hugo.Data.summaries -}}
   {{- if or (not $deiOnly) (in $s.Title "⌺") -}}
     {{/* Clean the title: drop the ◈ / ⌺ status symbols and any markdown. */}}
     {{- $name := trim ($s.Title | replaceRE "[◈⌺]" "" | plainify) " " -}}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,4 +1,4 @@
-      {{ $summaries := site.Data.summaries }}
+      {{ $summaries := hugo.Data.summaries }}
 
       <nav id="TableOfContents" class="nav flex-column">
         <ul>

--- a/layouts/partials/toc_dei.html
+++ b/layouts/partials/toc_dei.html
@@ -1,4 +1,4 @@
-{{ $summaries := site.Data.summaries }}
+{{ $summaries := hugo.Data.summaries }}
 
 <nav id="TableOfContents" class="nav flex-column">
   <ul>

--- a/layouts/shortcodes/ga_daily_visitors.html
+++ b/layouts/shortcodes/ga_daily_visitors.html
@@ -3,7 +3,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  var dailyData = {{ .Site.Data.ga_data.daily_visitors | jsonify | safeJS }};
+  var dailyData = {{ hugo.Data.ga_data.daily_visitors | jsonify | safeJS }};
   if (dailyData && dailyData.length) {
     dailyData.sort((a, b) => new Date(a.date) - new Date(b.date));
     dailyData.pop();

--- a/layouts/shortcodes/ga_daily_visitors_yearly.html
+++ b/layouts/shortcodes/ga_daily_visitors_yearly.html
@@ -1,11 +1,11 @@
 <!-- layouts/shortcodes/ga_daily_visitors_yearly.html -->
-{{ if .Site.Data.ga_data.daily_visitors_yearly }}
+{{ if hugo.Data.ga_data.daily_visitors_yearly }}
 <h3 id="-by-day-1">&hellip; by day</h3>
 <canvas id="visitorsChartYearly" width="400" height="200"></canvas>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-  var dailyData = {{ .Site.Data.ga_data.daily_visitors_yearly | jsonify | safeJS }};
+  var dailyData = {{ hugo.Data.ga_data.daily_visitors_yearly | jsonify | safeJS }};
   if (dailyData && dailyData.length) {
     dailyData.sort((a, b) => new Date(a.date) - new Date(b.date));
     dailyData.pop();

--- a/layouts/shortcodes/ga_map.html
+++ b/layouts/shortcodes/ga_map.html
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }).setView([40, 0], 1.25); // ✅ Adjust as needed
 
   // ✅ Define visitor data from Hugo
-  var gaRegionsData = {{ .Site.Data.ga_data.regions | jsonify | safeJS }};
+  var gaRegionsData = {{ hugo.Data.ga_data.regions | jsonify | safeJS }};
   var gaRegions = {};
   gaRegionsData.forEach(function(entry) {
     gaRegions[entry.country] = entry.users;

--- a/layouts/shortcodes/ga_map_yearly.html
+++ b/layouts/shortcodes/ga_map_yearly.html
@@ -1,4 +1,4 @@
-{{ if .Site.Data.ga_data.regions_yearly }}
+{{ if hugo.Data.ga_data.regions_yearly }}
 <h2 id="last-year">Last Year</h2>
 <h3 id="-by-country-1">&hellip; by country</h3>
 <div id="ga_map_yearly" style="height: 400px; background: #b3d9ff;"></div>
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }).setView([40, 0], 1.25);
 
   // Define visitor data from Hugo
-  var gaRegionsData = {{ .Site.Data.ga_data.regions_yearly | jsonify | safeJS }};
+  var gaRegionsData = {{ hugo.Data.ga_data.regions_yearly | jsonify | safeJS }};
   if (!gaRegionsData) {
     document.getElementById('ga_map_yearly').innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #666;">Yearly data not available yet</div>';
     return;

--- a/layouts/shortcodes/ga_top_pages.html
+++ b/layouts/shortcodes/ga_top_pages.html
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    {{ range first $limit .Site.Data.ga_data.top_pages }}
+    {{ range first $limit hugo.Data.ga_data.top_pages }}
     <tr>
       <td>
         {{ with .Site.GetPage .page }}

--- a/layouts/shortcodes/ga_top_pages_yearly.html
+++ b/layouts/shortcodes/ga_top_pages_yearly.html
@@ -1,5 +1,5 @@
 <!-- layouts/shortcodes/ga_top_pages_yearly.html -->
-{{ if .Site.Data.ga_data.top_pages_yearly }}
+{{ if hugo.Data.ga_data.top_pages_yearly }}
 <h3 id="-by-destination-1">&hellip; by destination</h3>
 {{ $limit := 10 }}
 {{ if .Get "limit" }}
@@ -13,7 +13,7 @@
     </tr>
   </thead>
   <tbody>
-    {{ range first $limit .Site.Data.ga_data.top_pages_yearly }}
+    {{ range first $limit hugo.Data.ga_data.top_pages_yearly }}
     <tr>
       <td>
         {{ with .Site.GetPage .page }}

--- a/layouts/shortcodes/get_involved_projects.html
+++ b/layouts/shortcodes/get_involved_projects.html
@@ -3,7 +3,7 @@
   Source CSV is in scripts/get_involved/projects.csv (mirrors a Google Sheet).
   Regenerate with: python scripts/build_get_involved.py
 */}}
-{{ $data := index site.Data "get_involved_projects" }}
+{{ $data := index hugo.Data "get_involved_projects" }}
 {{ $projects := $data.projects }}
 
 <div class="get-involved-projects" style="display: flex; flex-direction: column; gap: 1rem; margin-top: 1.5rem;">

--- a/layouts/shortcodes/glossary_language_switcher.html
+++ b/layouts/shortcodes/glossary_language_switcher.html
@@ -19,7 +19,7 @@
   {{- end -}}
 {{- end -}}
 <div class="btn-group flex-wrap text-center">
-{{- range $i, $lang := .Site.Data.glossary_languages -}}
+{{- range $i, $lang := hugo.Data.glossary_languages -}}
 {{- $active := "" -}}
 {{- if eq $lang.slug $current -}}{{- $active = " active" -}}{{- end -}}
 {{- if $i }}

--- a/layouts/shortcodes/partner_list.html
+++ b/layouts/shortcodes/partner_list.html
@@ -14,7 +14,7 @@
 {{ with (index $clusterAliases $cluster) }}
   {{ $clusters = $clusters | append . }}
 {{ end }}
-{{ $items := where site.Data.partners "cluster" "in" $clusters }}
+{{ $items := where hugo.Data.partners "cluster" "in" $clusters }}
 
 {{/* Cluster Map for CSS classes */}}
 {{ $clusterMap := dict

--- a/layouts/shortcodes/publication_list.html
+++ b/layouts/shortcodes/publication_list.html
@@ -1,6 +1,6 @@
 {{ $type := .Get "type" }}
 {{ $title := .Get "title" }}
-{{ $items := where site.Data.publications "type" $type }}
+{{ $items := where hugo.Data.publications "type" $type }}
 
 {{/* Centralized Type Map */}}
 {{ $typeMap := dict

--- a/layouts/shortcodes/summaries.html
+++ b/layouts/shortcodes/summaries.html
@@ -1,5 +1,5 @@
 {{ partial "structured-data/summaries-jsonld.html" (dict "page" .Page "deiOnly" false) }}
-{{ $summaries := site.Data.summaries }}
+{{ $summaries := hugo.Data.summaries }}
 {{ range $summaries }}
 
 <h2 id="{{.Id}}">{{ .Title | markdownify }}</h2>

--- a/layouts/shortcodes/summaries_dei.html
+++ b/layouts/shortcodes/summaries_dei.html
@@ -1,5 +1,5 @@
 {{ partial "structured-data/summaries-jsonld.html" (dict "page" .Page "deiOnly" true) }}
-{{ $summaries := site.Data.summaries }}
+{{ $summaries := hugo.Data.summaries }}
 {{ range $summaries}}
 {{ if in .Title "⌺" }}
 

--- a/themes/academic/layouts/_default/baseof.html
+++ b/themes/academic/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-{{- $language_code := site.LanguageCode | default "en-us" -}}
-<html lang="{{$language_code}}" {{ if in site.Data.i18n.rtl.rtl $language_code }}dir="rtl"{{end}}>
+{{- $language_code := site.Language.Locale | default "en-us" -}}
+<html lang="{{$language_code}}" {{ if in hugo.Data.i18n.rtl.rtl $language_code }}dir="rtl"{{end}}>
 
 {{ partial "site_head" . }}
 

--- a/themes/academic/layouts/_default/rss.xml
+++ b/themes/academic/layouts/_default/rss.xml
@@ -16,7 +16,7 @@
     {{ end -}}
     <description>{{ .Title | default site.Title }}</description>
     <generator>Source Themes Academic (https://sourcethemes.com/academic/)</generator>
-    {{- with site.LanguageCode }}<language>{{.}}</language>{{end -}}
+    {{- with site.Language.Locale }}<language>{{.}}</language>{{end -}}
     {{- with site.Copyright }}<copyright>{{ replace (replace . "{year}" now.Year) "&copy;" "©" | plainify }}</copyright>{{end -}}
     {{- if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end -}}
     {{- if .Scratch.Get "og_image" }}

--- a/themes/academic/layouts/partials/cookie_consent.html
+++ b/themes/academic/layouts/partials/cookie_consent.html
@@ -1,7 +1,7 @@
 {{ if site.Params.privacy_pack }}
   {{ $scr := .Scratch }}
-  {{ $js := site.Data.assets.js }}
-  {{ $css := site.Data.assets.css }}
+  {{ $js := hugo.Data.assets.js }}
+  {{ $css := hugo.Data.assets.css }}
   {{ if ($scr.Get "use_cdn") }}
     {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.cookieconsent.url $js.cookieconsent.version) $js.cookieconsent.sri | safeHTML }}
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.cookieconsent.url $css.cookieconsent.version) $css.cookieconsent.sri | safeHTML }}

--- a/themes/academic/layouts/partials/functions/get_address.html
+++ b/themes/academic/layouts/partials/functions/get_address.html
@@ -1,15 +1,15 @@
 {{/* Function to return a formatted address given a semantic address. */}}
 
 {{/* Check for valid site config. */}}
-{{ if not site.Data.address_formats }}{{errorf "Address formats missing from `data/address_formats.toml`!"}}{{end}}
+{{ if not hugo.Data.address_formats }}{{errorf "Address formats missing from `data/address_formats.toml`!"}}{{end}}
 
 {{ $page := . }}
 {{ $address := .address }}
 {{ $format_name := $page.Params.address_format | default site.Params.address_format | default "en-us" }}
 
-{{ if not (isset site.Data.address_formats $format_name) }}{{ errorf "Address format `%s` missing from `data/address_formats.toml`!" $format_name }}{{end}}
+{{ if not (isset hugo.Data.address_formats $format_name) }}{{ errorf "Address format `%s` missing from `data/address_formats.toml`!" $format_name }}{{end}}
 
-{{ $format := index site.Data.address_formats $format_name }}
+{{ $format := index hugo.Data.address_formats $format_name }}
 {{ $address_display := slice }}
 
 {{ range $k, $v := $format.order }}

--- a/themes/academic/layouts/partials/functions/get_pub_types.html
+++ b/themes/academic/layouts/partials/functions/get_pub_types.html
@@ -1,6 +1,6 @@
 {{/* Get Publication Types */}}
 {{ $pub_types := slice }}
-{{ range site.Data.publication_types.types }}
+{{ range hugo.Data.publication_types.types }}
   {{ $pub_types = $pub_types | append (i18n . | default "Uncategorized") }}
 {{ end }}
 {{ return $pub_types }}

--- a/themes/academic/layouts/partials/functions/parse_theme.html
+++ b/themes/academic/layouts/partials/functions/parse_theme.html
@@ -4,8 +4,8 @@
 {{- $theme_index := (site.Params.theme | lower | replaceRE "\\s" "_") | default "minimal" -}}
 
 {{/* Get name of site's Font Set. Precedence: Params.toml > Theme > Default (Minimal) */}}
-{{- $font_index := (site.Params.font | lower | replaceRE "\\s" "_") | default ((index site.Data.themes $theme_index).font | lower | replaceRE "\\s" "_") | default $theme_index -}}
-{{- $font_index := cond (isset site.Data.fonts $font_index) $font_index "minimal" -}}
+{{- $font_index := (site.Params.font | lower | replaceRE "\\s" "_") | default ((index hugo.Data.themes $theme_index).font | lower | replaceRE "\\s" "_") | default $theme_index -}}
+{{- $font_index := cond (isset hugo.Data.fonts $font_index) $font_index "minimal" -}}
 
 {{/* Get Font Size. */}}
 
@@ -17,7 +17,7 @@
 
 {{/* Load Font Set. */}}
 
-{{- $font := index site.Data.fonts $font_index -}}
+{{- $font := index hugo.Data.fonts $font_index -}}
 {{- $scr.Set "google_fonts" $font.google_fonts -}}
 {{- $scr.Set "body_font" $font.body_font -}}
 {{- $scr.Set "heading_font" $font.heading_font -}}
@@ -26,7 +26,7 @@
 
 {{/* Load Theme. */}}
 
-{{ $theme := index site.Data.themes $theme_index }}
+{{ $theme := index hugo.Data.themes $theme_index }}
 
 {{- $scr.Set "light" ($theme.light | default true) -}}
 

--- a/themes/academic/layouts/partials/navbar.html
+++ b/themes/academic/layouts/partials/navbar.html
@@ -169,16 +169,16 @@
         <a href="#" class="nav-link {{ if $show_current_language }}dropdown-toggle{{end}}" data-toggle="dropdown" aria-haspopup="true">
           <i class="fas fa-globe mr-1" aria-hidden="true"></i>
           {{- if $show_current_language -}}
-            <span class="d-none d-lg-inline">{{ index site.Data.i18n.languages .Lang }}</span>
+            <span class="d-none d-lg-inline">{{ index hugo.Data.i18n.languages .Lang }}</span>
           {{- end -}}
         </a>
         <div class="dropdown-menu">
           <div class="dropdown-item dropdown-item-active">
-            <span>{{ index site.Data.i18n.languages .Lang }}</span>
+            <span>{{ index hugo.Data.i18n.languages .Lang }}</span>
           </div>
           {{ range .Translations }}
           <a class="dropdown-item" href="{{ .Permalink }}"{{ if $.IsHome }} data-target="{{ .RelPermalink }}"{{ end }}>
-            <span>{{ index site.Data.i18n.languages .Lang }}</span>
+            <span>{{ index hugo.Data.i18n.languages .Lang }}</span>
           </a>
           {{ end }}
         </div>

--- a/themes/academic/layouts/partials/share.html
+++ b/themes/academic/layouts/partials/share.html
@@ -1,7 +1,7 @@
 {{ if and site.Params.sharing (ne .Params.share false) }}
 <div class="share-box" aria-hidden="true">
   <ul class="share">
-    {{ range where site.Data.page_sharer.buttons "enable" true }}
+    {{ range where hugo.Data.page_sharer.buttons "enable" true }}
       {{ $pack := or .icon_pack "fas" }}
       {{ $pack_prefix := $pack }}
       {{ if in (slice "fab" "fas" "far" "fal") $pack }}

--- a/themes/academic/layouts/partials/site_head.html
+++ b/themes/academic/layouts/partials/site_head.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
+  <meta name="generator" content="Source Themes Academic {{ hugo.Data.academic.version }}">
 
   {{ $scr := .Scratch }}
 
@@ -48,11 +48,11 @@
   {{ range .Translations }}
   <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
   {{ end }}
-  <link rel="alternate" hreflang="{{ site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}">
+  <link rel="alternate" hreflang="{{ site.Language.Locale | default "en-us" }}" href="{{ .Permalink }}">
 
   {{ partial "functions/parse_theme" . }}
-  {{ $css := site.Data.assets.css }}
-  {{ $js := site.Data.assets.js }}
+  {{ $css := hugo.Data.assets.css }}
+  {{ $js := hugo.Data.assets.js }}
   {{ if ne ($scr.Get "primary") "#fff" }}
   <meta name="theme-color" content="{{ $scr.Get "primary" }}">
   {{ end }}
@@ -111,7 +111,7 @@
     {{ end }}
 
     {{/* Load async scripts. */}}
-    {{ range $k, $v := site.Data.assets.js }}{{/* TODO: investigate why `where ... "async" true` does not work. */}}
+    {{ range $k, $v := hugo.Data.assets.js }}{{/* TODO: investigate why `where ... "async" true` does not work. */}}
       {{ $load := $v.async }}
 
       {{/* Only load MathJax if required. */}}
@@ -139,7 +139,7 @@
     {{ end }}
   {{ end }}
 
-  {{ $css_comment := printf "/*!* Source Themes Academic v%s (https://sourcethemes.com/academic/) */\n" site.Data.academic.version }}
+  {{ $css_comment := printf "/*!* Source Themes Academic v%s (https://sourcethemes.com/academic/) */\n" hugo.Data.academic.version }}
   {{ $css_bundle_head := $css_comment | resources.FromString "css/bundle-head.css" }}
   {{ $css_options := dict "targetPath" "css/academic.css" }}
   {{- if (in (slice (getenv "HUGO_ENV") hugo.Environment) "production") -}}
@@ -207,7 +207,7 @@
   <meta property="og:image" content="{{.}}">
   <meta property="twitter:image" content="{{.}}">
   {{- end -}}
-  <meta property="og:locale" content="{{ site.LanguageCode | default "en-us" }}">
+  <meta property="og:locale" content="{{ site.Language.Locale | default "en-us" }}">
   {{ if .IsPage }}
     {{ if not .PublishDate.IsZero }}
       <meta property="article:published_time" content="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">

--- a/themes/academic/layouts/partials/site_js.html
+++ b/themes/academic/layouts/partials/site_js.html
@@ -1,7 +1,7 @@
     {{ $scr := $.Scratch }}
 
     {{/* Attempt to load local vendor JS, otherwise load from CDN. */}}
-    {{ $js := site.Data.assets.js }}
+    {{ $js := hugo.Data.assets.js }}
     {{ if not ($scr.Get "use_cdn") }}
       <script src="{{ printf "/js/vendor/%s" ($scr.Get "vendor_js_filename") | relURL }}"></script>
     {{ else }}
@@ -146,7 +146,7 @@
     <script id="dsq-count-scr" src="https://{{site.Params.comments.disqus.shortname}}.disqus.com/count.js" async></script>
     {{ end }}
 
-    {{ $js_comment := printf "/* Source Themes Academic v%s | https://sourcethemes.com/academic/ */\n" site.Data.academic.version }}
+    {{ $js_comment := printf "/* Source Themes Academic v%s | https://sourcethemes.com/academic/ */\n" hugo.Data.academic.version }}
     {{ $js_bundle_head := $js_comment | resources.FromString "js/bundle-head.js" }}
     {{ $js_linebreak := "\n" | resources.FromString "js/linebreak.js" }}{{/* Fix no line break after Bootstrap JS causing error. */}}
     {{ $js_academic := resources.Get "js/academic.js" }}

--- a/themes/academic/layouts/slides/baseof.html
+++ b/themes/academic/layouts/slides/baseof.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<html lang="{{ site.LanguageCode | default "en-us" }}">
+<html lang="{{ site.Language.Locale | default "en-us" }}">
 <head>
   {{ $media_dir := site.Params.media_dir | default "media" }}
   {{ .Scratch.Set "media_dir" $media_dir }}
 
-  {{ $css := site.Data.assets.css }}
+  {{ $css := hugo.Data.assets.css }}
   {{ $cdn_url_reveal := "https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0" }}
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
+  <meta name="generator" content="Source Themes Academic {{ hugo.Data.academic.version }}">
 
   <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
   <link rel="icon" type="image/png" href="{{(partial "functions/get_icon" 32).RelPermalink}}">


### PR DESCRIPTION
## Description
<!-- Brief summary of the change -->

Trailing periods in tags — Four curated resource files had tags like "Statistics." or "Methodological Reform." with a period at the end. Hugo turns tags into URL paths, and Windows forbids folder/file names ending with a period. Removed the trailing periods from all four tags.

Deprecated _build front matter — Two files used _build: which Hugo removed in v0.145.0. Renamed to build: which is the current key.

Why it only breaks on Windows:

macOS and Linux filesystems allow directory names ending with ., so the site builds fine there. Windows (NTFS) silently strips or rejects trailing periods in paths, causing Hugo to error out. The fix is cross-platform safe — removing a trailing period from a tag doesn't affect anything on macOS/Linux either.

 additionally the deprecation fixes:
.Site.LanguageCode → site.Language.Locale (deprecated Hugo v0.158.0)

## Type of Change
- [x] Content/documentation update
- [x] Bug fix

## Testing
- [x] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
