### PR TITLE
Group steering-committee teams with connecting colour bars (#808)

### DIFF
--- a/content/about/steering-committee/index.md
+++ b/content/about/steering-committee/index.md
@@ -29,74 +29,102 @@ layout: single
         <p class="sc-section-desc">Core mission-driven teams advancing open scholarship, social justice, and community sustainability.</p>
     </div>
     <div class="sc-grid">
-        <div class="sc-title-card teal">
+        <div class="sc-title-card" style="--team-color:#0f766e;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Community & Sustainability</h3>
-</div><div class="sc-card" onclick="openModal('drstevenverheyen')">
-    <img src="/authors/drstevenverheyen/avatar.webp" alt="dr. Steven Verheyen" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drstevenverheyen')" style="--team-color:#0f766e;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drstevenverheyen/avatar.webp" alt="dr. Steven Verheyen" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">dr. Steven Verheyen</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('adiradaniel')">
-    <img src="/authors/adiradaniel/avatar.webp" alt="Adira Daniel " class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('adiradaniel')" style="--team-color:#0f766e;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/adiradaniel/avatar.webp" alt="Adira Daniel " class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Adira Daniel </h4>
         <p class="sc-card-role">Co-Director</p>
     </div>
-</div><div class="sc-title-card teal">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#2563eb;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Social Justice & DEIA</h3>
-</div><div class="sc-card" onclick="openModal('drsarahasauve')">
-    <img src="/authors/drsarahasauve/avatar.webp" alt="Dr. Sarah A. Sauvé" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drsarahasauve')" style="--team-color:#2563eb;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/drsarahasauve/avatar.webp" alt="Dr. Sarah A. Sauvé" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr. Sarah A. Sauvé</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-title-card teal">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#7c3aed;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Meta-science & Research</h3>
-</div><div class="sc-card" onclick="openModal('drrachelheyard')">
-    <img src="/authors/drrachelheyard/avatar.webp" alt="Dr Rachel Heyard" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drrachelheyard')" style="--team-color:#7c3aed;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drrachelheyard/avatar.webp" alt="Dr Rachel Heyard" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Rachel Heyard</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('tomheyman')">
-    <img src="/authors/tomheyman/avatar.webp" alt="Tom Heyman" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('tomheyman')" style="--team-color:#7c3aed;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/tomheyman/avatar.webp" alt="Tom Heyman" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Tom Heyman</h4>
         <p class="sc-card-role">Deputy-Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('berittbarthelmesmsc')">
-    <img src="/authors/berittbarthelmesmsc/avatar.webp" alt="Berit T. Barthelmes, M.Sc." class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('berittbarthelmesmsc')" style="--team-color:#7c3aed;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/berittbarthelmesmsc/avatar.webp" alt="Berit T. Barthelmes, M.Sc." class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Berit T. Barthelmes, M.Sc.</h4>
         <p class="sc-card-role">Project Manager</p>
     </div>
-</div><div class="sc-title-card teal">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#be123c;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Education & Pedagogy</h3>
-</div><div class="sc-card" onclick="openModal('drmadeleinepownall')">
-    <img src="/authors/drmadeleinepownall/avatar.webp" alt="Dr Madeleine Pownall" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drmadeleinepownall')" style="--team-color:#be123c;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drmadeleinepownall/avatar.webp" alt="Dr Madeleine Pownall" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Madeleine Pownall</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('lornahamilton')">
-    <img src="/authors/lornahamilton/avatar.webp" alt="Lorna Hamilton" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('lornahamilton')" style="--team-color:#be123c;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/lornahamilton/avatar.webp" alt="Lorna Hamilton" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Lorna Hamilton</h4>
         <p class="sc-card-role">Deputy-Director</p>
     </div>
+    <span class="sc-cbar"></span>
 </div>
     </div>
 </section><section class="sc-section" id="operations">
@@ -108,176 +136,246 @@ layout: single
         <p class="sc-section-desc">Infrastructure, community management, ethical oversight, and support systems powering FORRT.</p>
     </div>
     <div class="sc-grid">
-        <div class="sc-title-card slate">
+        <div class="sc-title-card" style="--team-color:#0f766e;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Community Governance & Management</h3>
-</div><div class="sc-card" onclick="openModal('dramandakaymontoya')">
-    <img src="/authors/dramandakaymontoya/avatar.webp" alt="Dr. Amanda Kay Montoya" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('dramandakaymontoya')" style="--team-color:#0f766e;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/dramandakaymontoya/avatar.webp" alt="Dr. Amanda Kay Montoya" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr. Amanda Kay Montoya</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('drkellylloyd')">
-    <img src="/authors/drkellylloyd/avatar.webp" alt="Dr Kelly Lloyd" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drkellylloyd')" style="--team-color:#0f766e;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drkellylloyd/avatar.webp" alt="Dr Kelly Lloyd" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Kelly Lloyd</h4>
         <p class="sc-card-role">Cohesion-Liaison</p>
     </div>
-</div><div class="sc-card" onclick="openModal('giorgiaandreolli')">
-    <img src="/authors/giorgiaandreolli/avatar.webp" alt="Giorgia Andreolli" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('giorgiaandreolli')" style="--team-color:#0f766e;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/giorgiaandreolli/avatar.webp" alt="Giorgia Andreolli" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Giorgia Andreolli</h4>
         <p class="sc-card-role">Cohesion-Liaison</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#2563eb;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Community Engagement</h3>
-</div><div class="sc-card" onclick="openModal('drlukasroseler')">
-    <img src="/authors/drlukasroseler/avatar.webp" alt="Dr. Lukas Röseler" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drlukasroseler')" style="--team-color:#2563eb;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/drlukasroseler/avatar.webp" alt="Dr. Lukas Röseler" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr. Lukas Röseler</h4>
         <p class="sc-card-role">Infrastructure-Liaison</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#7c3aed;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Sustainability & Strategy</h3>
-</div><div class="sc-card" onclick="openModal('drsarahashcroftjones')">
-    <img src="/authors/drsarahashcroftjones/avatar.webp" alt="Dr Sarah Ashcroft-Jones" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drsarahashcroftjones')" style="--team-color:#7c3aed;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drsarahashcroftjones/avatar.webp" alt="Dr Sarah Ashcroft-Jones" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Sarah Ashcroft-Jones</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('saralilmiddleton')">
-    <img src="/authors/saralilmiddleton/avatar.webp" alt="Sara Lil Middleton" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('saralilmiddleton')" style="--team-color:#7c3aed;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/saralilmiddleton/avatar.webp" alt="Sara Lil Middleton" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Sara Lil Middleton</h4>
         <p class="sc-card-role">Knowledge Manager</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#be123c;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Ethics and Inclusion</h3>
-</div><div class="sc-card" onclick="openModal('drjohnshaw')">
-    <img src="/authors/drjohnshaw/avatar.webp" alt="Dr John Shaw" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drjohnshaw')" style="--team-color:#be123c;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drjohnshaw/avatar.webp" alt="Dr John Shaw" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr John Shaw</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('thomasrhysevans')">
-    <img src="/authors/thomasrhysevans/avatar.webp" alt="Thomas Rhys Evans" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('thomasrhysevans')" style="--team-color:#be123c;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/thomasrhysevans/avatar.webp" alt="Thomas Rhys Evans" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Thomas Rhys Evans</h4>
         <p class="sc-card-role">Advisor</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#b45309;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Fundraising</h3>
-</div><div class="sc-card" onclick="openModal('drmaxkorbmacher')">
-    <img src="/authors/drmaxkorbmacher/avatar.webp" alt="Dr Max Korbmacher" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('drmaxkorbmacher')" style="--team-color:#b45309;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/drmaxkorbmacher/avatar.webp" alt="Dr Max Korbmacher" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Max Korbmacher</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('karenmatvienkosikar')">
-    <img src="/authors/karenmatvienkosikar/avatar.webp" alt="Karen Matvienko-Sikar" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('karenmatvienkosikar')" style="--team-color:#b45309;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/karenmatvienkosikar/avatar.webp" alt="Karen Matvienko-Sikar" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Karen Matvienko-Sikar</h4>
         <p class="sc-card-role">Co-Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('fotismystakopoulosphdstudent')">
-    <img src="/authors/fotismystakopoulosphdstudent/avatar.webp" alt="Fotis Mystakopoulos, PhD Student" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('fotismystakopoulosphdstudent')" style="--team-color:#b45309;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/fotismystakopoulosphdstudent/avatar.webp" alt="Fotis Mystakopoulos, PhD Student" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Fotis Mystakopoulos, PhD Student</h4>
         <p class="sc-card-role">Officer</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#0891b2;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Financial Transparency</h3>
-</div><div class="sc-card" onclick="openModal('aliciatamaraveersmabarredo')">
-    <img src="/authors/aliciatamaraveersmabarredo/avatar.webp" alt="Alicia Tamara Veersma Barredo" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('aliciatamaraveersmabarredo')" style="--team-color:#0891b2;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/aliciatamaraveersmabarredo/avatar.webp" alt="Alicia Tamara Veersma Barredo" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Alicia Tamara Veersma Barredo</h4>
         <p class="sc-card-role">Officer</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#4d7c0f;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Partnerships</h3>
-</div><div class="sc-card" onclick="openModal('adampartridge')">
-    <img src="/authors/adampartridge/avatar.webp" alt="Adam Partridge" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('adampartridge')" style="--team-color:#4d7c0f;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/adampartridge/avatar.webp" alt="Adam Partridge" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Adam Partridge</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#db2777;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Digital Infrastructure Team</h3>
-</div><div class="sc-card" onclick="openModal('justinsulik')">
-    <img src="/authors/justinsulik/avatar.webp" alt="Justin Sulik" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('justinsulik')" style="--team-color:#db2777;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/justinsulik/avatar.webp" alt="Justin Sulik" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Justin Sulik</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-card" onclick="openModal('dushimemudaherarichard')">
-    <img src="/authors/dushimemudaherarichard/avatar.webp" alt="Dushime Mudahera Richard" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('dushimemudaherarichard')" style="--team-color:#db2777;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/dushimemudaherarichard/avatar.webp" alt="Dushime Mudahera Richard" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dushime Mudahera Richard</h4>
         <p class="sc-card-role">Website Lead</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#475569;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">Communication, Dissemination & Impact</h3>
-</div><div class="sc-card" onclick="openModal('charlottepennington')">
-    <img src="/authors/charlottepennington/avatar.webp" alt="Charlotte Pennington" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('charlottepennington')" style="--team-color:#475569;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/charlottepennington/avatar.webp" alt="Charlotte Pennington" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Charlotte Pennington</h4>
         <p class="sc-card-role">Director</p>
     </div>
-</div><div class="sc-title-card slate">
+    <span class="sc-cbar"></span>
+</div><div class="sc-title-card" style="--team-color:#a16207;--bar-extend:calc(1rem + 1px)">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">FORRT Stewards</h3>
-</div><div class="sc-card" onclick="openModal('stephaniezellers')">
-    <img src="/authors/stephaniezellers/avatar.webp" alt="Stephanie Zellers" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('stephaniezellers')" style="--team-color:#a16207;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/stephaniezellers/avatar.webp" alt="Stephanie Zellers" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Stephanie Zellers</h4>
         <p class="sc-card-role">FORRT Steward</p>
     </div>
-</div><div class="sc-card" onclick="openModal('roksanasobolak')">
-    <img src="/authors/roksanasobolak/avatar.webp" alt="Roksana Sobolak" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('roksanasobolak')" style="--team-color:#a16207;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/roksanasobolak/avatar.webp" alt="Roksana Sobolak" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Roksana Sobolak</h4>
         <p class="sc-card-role">FORRT Steward</p>
     </div>
-</div><div class="sc-card" onclick="openModal('rivaquiroga')">
-    <img src="/authors/rivaquiroga/avatar.webp" alt="Riva Quiroga" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('rivaquiroga')" style="--team-color:#a16207;--bar-extend:calc(1rem + 1px)">
+    <div class="sc-card-photo">
+        <img src="/authors/rivaquiroga/avatar.webp" alt="Riva Quiroga" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Riva Quiroga</h4>
         <p class="sc-card-role">FORRT Steward</p>
     </div>
-</div><div class="sc-card" onclick="openModal('meerachandra')">
-    <img src="/authors/meerachandra/avatar.webp" alt="Meera Chandra" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <span class="sc-cbar"></span>
+</div><div class="sc-card" onclick="openModal('meerachandra')" style="--team-color:#a16207;--bar-extend:0px">
+    <div class="sc-card-photo">
+        <img src="/authors/meerachandra/avatar.webp" alt="Meera Chandra" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Meera Chandra</h4>
         <p class="sc-card-role">FORRT Steward</p>
     </div>
+    <span class="sc-cbar"></span>
 </div>
     </div>
 </section><section class="sc-section" id="steering">
@@ -290,15 +388,19 @@ layout: single
     </div>
     <div class="sc-grid">
         <div class="sc-card" onclick="openModal('drlukaswallrich')">
-    <img src="/authors/drlukaswallrich/avatar.webp" alt="Dr Lukas Wallrich" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <div class="sc-card-photo">
+        <img src="/authors/drlukaswallrich/avatar.webp" alt="Dr Lukas Wallrich" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Lukas Wallrich</h4>
         <p class="sc-card-role">Co-Director</p>
     </div>
 </div><div class="sc-card" onclick="openModal('drflavioazevedo')">
-    <img src="/authors/drflavioazevedo/avatar.webp" alt="Dr Flavio Azevedo" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <div class="sc-card-photo">
+        <img src="/authors/drflavioazevedo/avatar.webp" alt="Dr Flavio Azevedo" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Dr Flavio Azevedo</h4>
         <p class="sc-card-role">Director</p>
@@ -315,15 +417,19 @@ layout: single
     </div>
     <div class="sc-grid">
         <div class="sc-card" onclick="openModal('samparsons')">
-    <img src="/authors/samparsons/avatar.webp" alt="Sam Parsons" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <div class="sc-card-photo">
+        <img src="/authors/samparsons/avatar.webp" alt="Sam Parsons" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Sam Parsons</h4>
         <p class="sc-card-role">Stewardship Panel</p>
     </div>
 </div><div class="sc-card" onclick="openModal('thomasrhysevans')">
-    <img src="/authors/thomasrhysevans/avatar.webp" alt="Thomas Rhys Evans" class="sc-card-img" />
-    <div class="sc-card-overlay"></div>
+    <div class="sc-card-photo">
+        <img src="/authors/thomasrhysevans/avatar.webp" alt="Thomas Rhys Evans" class="sc-card-img" />
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">Thomas Rhys Evans</h4>
         <p class="sc-card-role">Ombudsman</p>
@@ -1189,223 +1295,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     });
-
-    /* --- Team linking + ordering based on source CSV --- */
-    const SC_ORDER_CSV = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRCHSY7WBvzDSSWyUyOVPRbsf5QxO7Mc40hGB7yanfT-rjbcNthMbHvUxT0NJ3AAfLKfx4YiOghByZT/pub?output=csv";
-    const TEAM_COLORS = ["#2563eb","#c026d3","#ea580c","#22c55e","#0ea5e9","#f59e0b","#ef4444","#8b5cf6","#14b8a6","#f97316"];
-    const BACKGROUND_COLORS = ["#0f766e", "#475569"];
-    const honorifics = /^(dr|dr\.|prof|prof\.|mr|mrs|ms|miss)\s+/i;
-    const normalizeBase = (str = "") => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-    const normalizeText = (str = "") => normalizeBase(str.replace(/&amp;/gi, "&").trim().toLowerCase());
-    const normalizeTeam = (str = "") => normalizeText(str).replace(/\s+/g, " ");
-    const nameTokens = (str = "") =>
-        normalizeText(str.replace(honorifics, ""))
-            .replace(/[^a-z0-9\s]/g, " ")
-            .split(/\s+/)
-            .filter(Boolean);
-
-    const tokenSimilarity = (aTokens, bTokens) => {
-        if (!aTokens.length || !bTokens.length) return 0;
-        const aSet = new Set(aTokens);
-        const bSet = new Set(bTokens);
-        let intersect = 0;
-        bSet.forEach((t) => {
-            if (aSet.has(t)) intersect += 1;
-        });
-        return intersect / Math.max(aSet.size, bSet.size, 1);
-    };
-
-    const charDice = (aStr, bStr) => {
-        const a = aStr.replace(/\s+/g, "");
-        const b = bStr.replace(/\s+/g, "");
-        if (!a.length || !b.length) return 0;
-        const count = (s) => {
-            const m = {};
-            for (const ch of s) m[ch] = (m[ch] || 0) + 1;
-            return m;
-        };
-        const aCount = count(a);
-        const bCount = count(b);
-        let overlap = 0;
-        Object.keys(aCount).forEach((ch) => {
-            if (bCount[ch]) overlap += Math.min(aCount[ch], bCount[ch]);
-        });
-        return (2 * overlap) / (a.length + b.length);
-    };
-
-    const parseCSV = (text) =>
-        text
-            .trim()
-            .split(/\\r?\\n/)
-            .map((line) => line.split(",").map((cell) => cell.replace(/^"+|"+$/g, "").trim()));
-
-    const buildOrders = (rows) => {
-        const sectionMap = {};
-        document.querySelectorAll(".sc-section").forEach((sec) => {
-            const title = sec.querySelector(".sc-section-title span")?.textContent || sec.id;
-            sectionMap[normalizeTeam(title)] = sec.id;
-        });
-
-        const findSection = (raw) => {
-            const key = normalizeTeam(raw);
-            if (sectionMap[key]) return sectionMap[key];
-
-            const operationsId = Object.entries(sectionMap).find(([k]) => k.includes('operation'))?.[1];
-            if (operationsId && (key.includes('ombudsman') || key.includes('steward'))) {
-                return operationsId;
-            }
-
-            let best = null;
-            let bestScore = -1;
-            Object.entries(sectionMap).forEach(([k, id]) => {
-                const score = charDice(k, key);
-                if (score > bestScore) {
-                    bestScore = score;
-                    best = id;
-                }
-            });
-            return best || Object.values(sectionMap)[0] || null;
-        };
-
-        const orders = {};
-        rows.slice(1).forEach((row) => {
-            const sectionRaw = row[1];
-            const teamRaw = row[3];
-            const nameRaw = row[5];
-            if (!sectionRaw || !teamRaw || !nameRaw) return;
-            const secKey = findSection(sectionRaw);
-            if (!secKey) return;
-            if (!orders[secKey]) orders[secKey] = [];
-            let group = orders[secKey].find((g) => normalizeTeam(g.team) === normalizeTeam(teamRaw));
-            if (!group) {
-                group = { team: teamRaw, members: [] };
-                orders[secKey].push(group);
-            }
-            group.members.push(nameRaw);
-        });
-        return orders;
-    };
-
-    const reorderAndLink = (sectionId, teams) => {
-        const grid = document.querySelector(`#${sectionId} .sc-grid`);
-        if (!grid || !teams || !teams.length) return;
-
-        const titleCards = Array.from(grid.querySelectorAll('.sc-title-card'));
-        const memberCards = Array.from(grid.querySelectorAll('.sc-card'));
-
-        [...titleCards, ...memberCards].forEach((el) => {
-            el.classList.remove('sc-team-linked', 'sc-team-title');
-            el.style.removeProperty('--team-color');
-        });
-
-        const titleMap = new Map();
-        titleCards.forEach((card) => {
-            const text = card.querySelector('.sc-title-text')?.textContent || "";
-            titleMap.set(normalizeTeam(text), card);
-        });
-
-        const memberMap = [];
-        memberCards.forEach((card) => {
-            const name = card.querySelector('.sc-card-name')?.textContent || "";
-            const tokens = nameTokens(name);
-            if (!tokens.length) return;
-            memberMap.push({ tokens, card });
-        });
-
-        const takeMember = (rawName) => {
-            const targetTokens = nameTokens(rawName);
-            if (!targetTokens.length) return null;
-            const targetJoined = targetTokens.join("");
-
-            let best = null;
-            let bestScore = 0.45;
-
-            memberMap.forEach((entry, idx) => {
-                const tokenScore = tokenSimilarity(entry.tokens, targetTokens);
-                const joined = entry.tokens.join("");
-                const charScore = charDice(joined, targetJoined);
-                const score = Math.max(tokenScore, charScore);
-                if (score > bestScore) {
-                    bestScore = score;
-                    best = { idx, card: entry.card };
-                }
-            });
-
-            if (best) {
-                memberMap.splice(best.idx, 1);
-                return best.card;
-            }
-            return null;
-        };
-
-        let colorIndex = 0;
-        const parseColor = (hex) => {
-            const h = hex.replace("#", "");
-            const r = parseInt(h.substring(0, 2), 16) / 255;
-            const g = parseInt(h.substring(2, 4), 16) / 255;
-            const b = parseInt(h.substring(4, 6), 16) / 255;
-            const toLin = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
-            return { r: toLin(r), g: toLin(g), b: toLin(b) };
-        };
-        const contrast = (hex1, hex2) => {
-            const a = parseColor(hex1);
-            const b = parseColor(hex2);
-            const lum = ({ r, g, b }) => 0.2126 * r + 0.7152 * g + 0.0722 * b;
-            const l1 = lum(a) + 0.05;
-            const l2 = lum(b) + 0.05;
-            return l1 > l2 ? l1 / l2 : l2 / l1;
-        };
-        const nextColor = () => {
-            let attempts = 0;
-            while (attempts < TEAM_COLORS.length * 2) {
-                const color = TEAM_COLORS[colorIndex % TEAM_COLORS.length];
-                colorIndex += 1;
-                const ok = BACKGROUND_COLORS.every((bg) => contrast(color, bg) > 4);
-                if (ok) return color;
-                attempts += 1;
-            }
-            return TEAM_COLORS[(colorIndex++) % TEAM_COLORS.length];
-        };
-
-        const newChildren = [];
-
-        teams.forEach((team) => {
-            const color = nextColor();
-            const teamKey = normalizeTeam(team.team);
-            const titleCard = titleMap.get(teamKey);
-            if (titleCard) {
-                titleCard.style.setProperty('--team-color', color);
-                titleCard.classList.add('sc-team-title');
-                titleMap.delete(teamKey);
-                newChildren.push(titleCard);
-            }
-
-            team.members.forEach((memberName) => {
-                const card = takeMember(memberName);
-                if (card) {
-                    card.style.setProperty('--team-color', color);
-                    card.classList.add('sc-team-linked');
-                    newChildren.push(card);
-                }
-            });
-        });
-
-        const leftovers = [];
-        titleMap.forEach((card) => leftovers.push(card));
-        memberMap.forEach((entry) => leftovers.push(entry.card));
-
-        grid.innerHTML = '';
-        [...newChildren, ...leftovers].forEach((el) => grid.appendChild(el));
-    };
-
-    fetch(SC_ORDER_CSV)
-        .then((res) => res.text())
-        .then((text) => {
-            const rows = parseCSV(text);
-            const orders = buildOrders(rows);
-            Object.entries(orders).forEach(([sectionId, teams]) => reorderAndLink(sectionId, teams));
-        })
-        .catch((err) => console.warn('SC team linking failed', err));
 });
 </script>
 

--- a/scripts/generate_sc_profiles.py
+++ b/scripts/generate_sc_profiles.py
@@ -11,19 +11,26 @@ This script:
 6. Downloads profile pictures from Google Drive
 """
 
-import pandas as pd
 import os
 import shutil
 import re
-import requests
 import unicodedata
 import json
 import html
 from pathlib import Path
 from difflib import SequenceMatcher
 from urllib.parse import parse_qs, urlparse
-from PIL import Image
-from io import BytesIO
+
+# Heavy, network/data-only dependencies. Kept optional so the page templates and render
+# helpers in this module can be imported (e.g. by tooling that re-renders the page from
+# existing data) without installing pandas/requests/Pillow. main() requires them.
+try:
+    import pandas as pd
+    import requests
+    from PIL import Image
+    from io import BytesIO
+except ImportError:  # pragma: no cover - exercised only when deps are absent
+    pd = requests = Image = BytesIO = None
 
 # Configuration
 SC_CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRCHSY7WBvzDSSWyUyOVPRbsf5QxO7Mc40hGB7yanfT-rjbcNthMbHvUxT0NJ3AAfLKfx4YiOghByZT/pub?output=csv"
@@ -131,223 +138,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
     });
-
-    /* --- Team linking + ordering based on source CSV --- */
-    const SC_ORDER_CSV = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRCHSY7WBvzDSSWyUyOVPRbsf5QxO7Mc40hGB7yanfT-rjbcNthMbHvUxT0NJ3AAfLKfx4YiOghByZT/pub?output=csv";
-    const TEAM_COLORS = ["#2563eb","#c026d3","#ea580c","#22c55e","#0ea5e9","#f59e0b","#ef4444","#8b5cf6","#14b8a6","#f97316"];
-    const BACKGROUND_COLORS = ["#0f766e", "#475569"];
-    const honorifics = /^(dr|dr\.|prof|prof\.|mr|mrs|ms|miss)\s+/i;
-    const normalizeBase = (str = "") => str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-    const normalizeText = (str = "") => normalizeBase(str.replace(/&amp;/gi, "&").trim().toLowerCase());
-    const normalizeTeam = (str = "") => normalizeText(str).replace(/\s+/g, " ");
-    const nameTokens = (str = "") =>
-        normalizeText(str.replace(honorifics, ""))
-            .replace(/[^a-z0-9\s]/g, " ")
-            .split(/\s+/)
-            .filter(Boolean);
-
-    const tokenSimilarity = (aTokens, bTokens) => {
-        if (!aTokens.length || !bTokens.length) return 0;
-        const aSet = new Set(aTokens);
-        const bSet = new Set(bTokens);
-        let intersect = 0;
-        bSet.forEach((t) => {
-            if (aSet.has(t)) intersect += 1;
-        });
-        return intersect / Math.max(aSet.size, bSet.size, 1);
-    };
-
-    const charDice = (aStr, bStr) => {
-        const a = aStr.replace(/\s+/g, "");
-        const b = bStr.replace(/\s+/g, "");
-        if (!a.length || !b.length) return 0;
-        const count = (s) => {
-            const m = {};
-            for (const ch of s) m[ch] = (m[ch] || 0) + 1;
-            return m;
-        };
-        const aCount = count(a);
-        const bCount = count(b);
-        let overlap = 0;
-        Object.keys(aCount).forEach((ch) => {
-            if (bCount[ch]) overlap += Math.min(aCount[ch], bCount[ch]);
-        });
-        return (2 * overlap) / (a.length + b.length);
-    };
-
-    const parseCSV = (text) =>
-        text
-            .trim()
-            .split(/\\r?\\n/)
-            .map((line) => line.split(",").map((cell) => cell.replace(/^"+|"+$/g, "").trim()));
-
-    const buildOrders = (rows) => {
-        const sectionMap = {};
-        document.querySelectorAll(".sc-section").forEach((sec) => {
-            const title = sec.querySelector(".sc-section-title span")?.textContent || sec.id;
-            sectionMap[normalizeTeam(title)] = sec.id;
-        });
-
-        const findSection = (raw) => {
-            const key = normalizeTeam(raw);
-            if (sectionMap[key]) return sectionMap[key];
-
-            const operationsId = Object.entries(sectionMap).find(([k]) => k.includes('operation'))?.[1];
-            if (operationsId && (key.includes('ombudsman') || key.includes('steward'))) {
-                return operationsId;
-            }
-
-            let best = null;
-            let bestScore = -1;
-            Object.entries(sectionMap).forEach(([k, id]) => {
-                const score = charDice(k, key);
-                if (score > bestScore) {
-                    bestScore = score;
-                    best = id;
-                }
-            });
-            return best || Object.values(sectionMap)[0] || null;
-        };
-
-        const orders = {};
-        rows.slice(1).forEach((row) => {
-            const sectionRaw = row[1];
-            const teamRaw = row[3];
-            const nameRaw = row[5];
-            if (!sectionRaw || !teamRaw || !nameRaw) return;
-            const secKey = findSection(sectionRaw);
-            if (!secKey) return;
-            if (!orders[secKey]) orders[secKey] = [];
-            let group = orders[secKey].find((g) => normalizeTeam(g.team) === normalizeTeam(teamRaw));
-            if (!group) {
-                group = { team: teamRaw, members: [] };
-                orders[secKey].push(group);
-            }
-            group.members.push(nameRaw);
-        });
-        return orders;
-    };
-
-    const reorderAndLink = (sectionId, teams) => {
-        const grid = document.querySelector(`#${sectionId} .sc-grid`);
-        if (!grid || !teams || !teams.length) return;
-
-        const titleCards = Array.from(grid.querySelectorAll('.sc-title-card'));
-        const memberCards = Array.from(grid.querySelectorAll('.sc-card'));
-
-        [...titleCards, ...memberCards].forEach((el) => {
-            el.classList.remove('sc-team-linked', 'sc-team-title');
-            el.style.removeProperty('--team-color');
-        });
-
-        const titleMap = new Map();
-        titleCards.forEach((card) => {
-            const text = card.querySelector('.sc-title-text')?.textContent || "";
-            titleMap.set(normalizeTeam(text), card);
-        });
-
-        const memberMap = [];
-        memberCards.forEach((card) => {
-            const name = card.querySelector('.sc-card-name')?.textContent || "";
-            const tokens = nameTokens(name);
-            if (!tokens.length) return;
-            memberMap.push({ tokens, card });
-        });
-
-        const takeMember = (rawName) => {
-            const targetTokens = nameTokens(rawName);
-            if (!targetTokens.length) return null;
-            const targetJoined = targetTokens.join("");
-
-            let best = null;
-            let bestScore = 0.45;
-
-            memberMap.forEach((entry, idx) => {
-                const tokenScore = tokenSimilarity(entry.tokens, targetTokens);
-                const joined = entry.tokens.join("");
-                const charScore = charDice(joined, targetJoined);
-                const score = Math.max(tokenScore, charScore);
-                if (score > bestScore) {
-                    bestScore = score;
-                    best = { idx, card: entry.card };
-                }
-            });
-
-            if (best) {
-                memberMap.splice(best.idx, 1);
-                return best.card;
-            }
-            return null;
-        };
-
-        let colorIndex = 0;
-        const parseColor = (hex) => {
-            const h = hex.replace("#", "");
-            const r = parseInt(h.substring(0, 2), 16) / 255;
-            const g = parseInt(h.substring(2, 4), 16) / 255;
-            const b = parseInt(h.substring(4, 6), 16) / 255;
-            const toLin = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
-            return { r: toLin(r), g: toLin(g), b: toLin(b) };
-        };
-        const contrast = (hex1, hex2) => {
-            const a = parseColor(hex1);
-            const b = parseColor(hex2);
-            const lum = ({ r, g, b }) => 0.2126 * r + 0.7152 * g + 0.0722 * b;
-            const l1 = lum(a) + 0.05;
-            const l2 = lum(b) + 0.05;
-            return l1 > l2 ? l1 / l2 : l2 / l1;
-        };
-        const nextColor = () => {
-            let attempts = 0;
-            while (attempts < TEAM_COLORS.length * 2) {
-                const color = TEAM_COLORS[colorIndex % TEAM_COLORS.length];
-                colorIndex += 1;
-                const ok = BACKGROUND_COLORS.every((bg) => contrast(color, bg) > 4);
-                if (ok) return color;
-                attempts += 1;
-            }
-            return TEAM_COLORS[(colorIndex++) % TEAM_COLORS.length];
-        };
-
-        const newChildren = [];
-
-        teams.forEach((team) => {
-            const color = nextColor();
-            const teamKey = normalizeTeam(team.team);
-            const titleCard = titleMap.get(teamKey);
-            if (titleCard) {
-                titleCard.style.setProperty('--team-color', color);
-                titleCard.classList.add('sc-team-title');
-                titleMap.delete(teamKey);
-                newChildren.push(titleCard);
-            }
-
-            team.members.forEach((memberName) => {
-                const card = takeMember(memberName);
-                if (card) {
-                    card.style.setProperty('--team-color', color);
-                    card.classList.add('sc-team-linked');
-                    newChildren.push(card);
-                }
-            });
-        });
-
-        const leftovers = [];
-        titleMap.forEach((card) => leftovers.push(card));
-        memberMap.forEach((entry) => leftovers.push(entry.card));
-
-        grid.innerHTML = '';
-        [...newChildren, ...leftovers].forEach((el) => grid.appendChild(el));
-    };
-
-    fetch(SC_ORDER_CSV)
-        .then((res) => res.text())
-        .then((text) => {
-            const rows = parseCSV(text);
-            const orders = buildOrders(rows);
-            Object.entries(orders).forEach(([sectionId, teams]) => reorderAndLink(sectionId, teams));
-        })
-        .catch((err) => console.warn('SC team linking failed', err));
 });
 </script>
 """
@@ -367,17 +157,50 @@ SECTION_TEMPLATE = r"""
 </section>
 """
 
+# Distinct, white-text-legible colour per team within a section. Operations has the most
+# teams (10), so the palette has 10 entries; sections restart the index, so no repeats
+# occur within a single section.
+TEAM_COLORS = [
+    "#0f766e", "#2563eb", "#7c3aed", "#be123c", "#b45309",
+    "#0891b2", "#4d7c0f", "#db2777", "#475569", "#a16207",
+]
+
+# How far a tile's connecting bar reaches past its right edge to bridge the flex gap to
+# the next tile in the same team (the grid gap is 1rem). Last tile in a team gets 0px, so
+# the bar stops cleanly; tiles mid-team extend, and at a row break the bar is clipped at
+# the row edge and resumes on the next row — a visible "this team continues" cue.
+BAR_EXTEND = "calc(1rem + 1px)"
+
 TEAM_TITLE_CARD_TEMPLATE = r"""
-<div class="sc-title-card {bg_class}">
+<div class="sc-title-card" style="--team-color:{color};--bar-extend:{extend}">
     <span class="sc-title-label">Team</span>
     <h3 class="sc-title-text">{name}</h3>
+    <span class="sc-cbar"></span>
 </div>
 """
 
+# Connected member card (teams with a title card): coloured connecting bar links it to its team.
 MEMBER_CARD_TEMPLATE = r"""
+<div class="sc-card" onclick="openModal('{id}')" style="--team-color:{color};--bar-extend:{extend}">
+    <div class="sc-card-photo">
+        {img_content}
+        <div class="sc-card-overlay"></div>
+    </div>
+    <div class="sc-card-content">
+        <h4 class="sc-card-name">{name}</h4>
+        <p class="sc-card-role">{role}</p>
+    </div>
+    <span class="sc-cbar"></span>
+</div>
+"""
+
+# Plain member card (sections without team titles, e.g. Steering & Guidance): no team bar.
+MEMBER_CARD_PLAIN_TEMPLATE = r"""
 <div class="sc-card" onclick="openModal('{id}')">
-    {img_content}
-    <div class="sc-card-overlay"></div>
+    <div class="sc-card-photo">
+        {img_content}
+        <div class="sc-card-overlay"></div>
+    </div>
     <div class="sc-card-content">
         <h4 class="sc-card-name">{name}</h4>
         <p class="sc-card-role">{role}</p>
@@ -513,6 +336,30 @@ def normalize_website_url(url):
     if not url.startswith("http://") and not url.startswith("https://"):
         return f"https://{url}"
     return url
+
+def render_title_card(name, color, has_members):
+    """Team title tile (the coloured anchor each team's connecting bar runs from)."""
+    return TEAM_TITLE_CARD_TEMPLATE.format(
+        name=name,
+        color=color,
+        extend=BAR_EXTEND if has_members else "0px",
+    ).strip()
+
+def render_member_card(member_id, name, role, img_content, color=None, is_last=False):
+    """Member tile. With a colour it carries the team's connecting bar; without, it is plain
+    (used by sections that have no team titles, e.g. Steering & Guidance)."""
+    if color is None:
+        return MEMBER_CARD_PLAIN_TEMPLATE.format(
+            id=member_id, name=name, role=role, img_content=img_content
+        ).strip()
+    return MEMBER_CARD_TEMPLATE.format(
+        id=member_id,
+        name=name,
+        role=role,
+        img_content=img_content,
+        color=color,
+        extend="0px" if is_last else BAR_EXTEND,
+    ).strip()
 
 def main():
     print("=" * 60)
@@ -680,24 +527,21 @@ def main():
         cat_details = CATEGORY_DETAILS[cat_key]
         
         cards_html = ""
-        
+        has_team_titles = cat_key in categories_with_team_titles
+
         # Keep teams in CSV order (insertion order)
-        for team_name in cat_data["order"]:
+        for team_index, team_name in enumerate(cat_data["order"]):
             members = cat_data["teams"][team_name]
-            
-            # Only Strategic and Operations display team title cards; Steering and Guidance list members directly.
-            if cat_key in categories_with_team_titles:
-                bg_class = "teal"
-                if cat_key == "operations":
-                    bg_class = "slate"
-                
-                cards_html += TEAM_TITLE_CARD_TEMPLATE.format(
-                    name=team_name,
-                    bg_class=bg_class
-                ).strip()
-            
+
+            # Only Strategic and Operations display team title cards (and the connecting
+            # bars that group each team); Steering and Guidance list members directly.
+            team_color = TEAM_COLORS[team_index % len(TEAM_COLORS)] if has_team_titles else None
+
+            if has_team_titles:
+                cards_html += render_title_card(team_name, team_color, has_members=bool(members))
+
             # Member Cards
-            for member in members:
+            for member_index, member in enumerate(members):
                 img_content = ""
                 if member["imgUrl"]:
                     img_content = f'<img src="{member["imgUrl"]}" alt="{member["name"]}" class="sc-card-img" />'
@@ -705,12 +549,11 @@ def main():
                     # Placeholder for missing image
                     img_content = f'<div class="sc-placeholder">{member["initials"]}</div>'
 
-                cards_html += MEMBER_CARD_TEMPLATE.format(
-                    id=member["id"],
-                    name=member["name"],
-                    role=member["role"],
-                    img_content=img_content
-                ).strip()
+                cards_html += render_member_card(
+                    member["id"], member["name"], member["role"], img_content,
+                    color=team_color,
+                    is_last=(member_index == len(members) - 1),
+                )
 
                 # Generate Modal for this member
                 img_content_large = ""

--- a/static/css/steering-committee.css
+++ b/static/css/steering-committee.css
@@ -133,6 +133,9 @@ article.article .article-container .article-title {
     gap: 1rem;
     padding: 0;
     justify-content: flex-start;
+    /* Top-align every tile so title cards and member cards (and their connecting bars)
+       always line up, regardless of any height differences or theme alignment defaults. */
+    align-items: flex-start;
     /* Clip the connecting team bars at the row/section edges so they break cleanly
        at the end of a row and resume on the next one (see .sc-cbar). */
     overflow: hidden;
@@ -157,12 +160,22 @@ article.article .article-container .article-title {
 }
 
 /* Clipped photo wrapper: holds the image + overlay so the zoom-on-hover and crop stay
-   contained, while the connecting bar (a direct child of .sc-card) can overflow. */
+   contained, while the connecting bar (a direct child of .sc-card) can overflow.
+   Positioning is forced so theme rules can never push the photo down inside the card. */
 .sc-card-photo {
-    position: absolute;
-    inset: 0;
+    position: absolute !important;
+    inset: 0 !important;
     overflow: hidden;
     background: #e2e8f0;
+    margin: 0 !important;
+}
+/* Guard against the theme wrapping the avatar in a lightbox <a>: make any such wrapper
+   fill the photo box so the image stays flush with the top of the card. */
+.sc-card-photo a {
+    position: absolute !important;
+    inset: 0 !important;
+    display: block !important;
+    margin: 0 !important;
 }
 
 @media (min-width: 640px) {
@@ -210,8 +223,10 @@ article.article .article-container .article-title {
 }
 
 .sc-card-img {
-    position: absolute;
-    inset: 0;
+    /* position/inset forced: the theme's `.article-style img` selector outranks this class,
+       so without !important it could drop the image into normal flow and misalign it. */
+    position: absolute !important;
+    inset: 0 !important;
     width: 100% !important; /* Force fill even if global img rules set height:auto */
     height: 100% !important;
     min-width: 100%;
@@ -348,7 +363,7 @@ article.article .article-container .article-title {
     letter-spacing: 0.1em;
     opacity: 0.9;
     color: #e2e8f0;
-    margin-bottom: 0.25rem;
+    margin: 0 0 0.25rem; /* reset theme heading/paragraph margins */
 }
 
 .sc-title-text {
@@ -356,6 +371,7 @@ article.article .article-container .article-title {
     font-weight: 700;
     line-height: 1.2;
     color: #f8fafc;
+    margin: 0; /* reset theme h3 margins so the title card can't grow past its aspect ratio */
 }
 
 /* Connecting team bar

--- a/static/css/steering-committee.css
+++ b/static/css/steering-committee.css
@@ -133,14 +133,18 @@ article.article .article-container .article-title {
     gap: 1rem;
     padding: 0;
     justify-content: flex-start;
+    /* Clip the connecting team bars at the row/section edges so they break cleanly
+       at the end of a row and resume on the next one (see .sc-cbar). */
+    overflow: hidden;
 }
 
 /* Cards */
 .sc-card {
     position: relative;
-    background: #e2e8f0;
     cursor: pointer;
-    overflow: hidden;
+    /* overflow stays visible so the connecting bar can reach into the gap; the photo
+       itself is clipped by .sc-card-photo. */
+    overflow: visible;
     border: 1px solid transparent;
     /* Portrait aspect ratio 2:3 */
     aspect-ratio: 2/3;
@@ -150,6 +154,15 @@ article.article .article-container .article-title {
     /* Absolute width for consistent sizing */
     width: 180px;
     flex-shrink: 0;
+}
+
+/* Clipped photo wrapper: holds the image + overlay so the zoom-on-hover and crop stay
+   contained, while the connecting bar (a direct child of .sc-card) can overflow. */
+.sc-card-photo {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    background: #e2e8f0;
 }
 
 @media (min-width: 640px) {
@@ -293,6 +306,8 @@ article.article .article-container .article-title {
 
 /* Title Cards */
 .sc-title-card {
+    position: relative;
+    overflow: visible; /* let the connecting bar reach into the gap toward the first member */
     aspect-ratio: 2/3;
     /* Match card aspect ratio */
     padding: 1rem;
@@ -300,6 +315,9 @@ article.article .article-container .article-title {
     flex-direction: column;
     justify-content: center;
     border: 0;
+    /* Per-team colour, set inline via --team-color */
+    background-color: var(--team-color, #0b5d55);
+    color: #f8fafc;
     /* Absolute width for consistent sizing */
     width: 180px;
     flex-shrink: 0;
@@ -323,16 +341,6 @@ article.article .article-container .article-title {
     }
 }
 
-.sc-title-card.teal {
-    background-color: #0b5d55; /* slightly darker teal */
-    color: #f8fafc;
-}
-
-.sc-title-card.slate {
-    background-color: #364152; /* deeper slate */
-    color: #f8fafc;
-}
-
 .sc-title-label {
     font-size: 0.65rem;
     font-weight: 700;
@@ -350,78 +358,21 @@ article.article .article-container .article-title {
     color: #f8fafc;
 }
 
-/* Team linkage styling */
-.sc-team-linked {
-    position: relative;
-    border-color: transparent;
-    box-shadow: none;
-}
-
-.sc-team-title {
-    position: relative;
-    border-color: transparent;
-    box-shadow: none;
-    overflow: hidden;
-}
-
-.sc-team-linked::before,
-.sc-team-linked::after,
-.sc-team-title::before,
-.sc-team-title::after {
-    content: "";
+/* Connecting team bar
+   A coloured rail along the top of every tile in a team (title + members). It reaches
+   --bar-extend past the tile's right edge to bridge the grid gap to the next tile in the
+   same team, so a team reads as one connected run. The last tile in a team uses
+   --bar-extend: 0, ending the run; the .sc-grid clips overflow, so when a team wraps the
+   bar is cut at the row edge and resumes on the next row. */
+.sc-cbar {
     position: absolute;
+    top: 0;
+    left: 0;
+    right: calc(-1 * var(--bar-extend, 0px));
+    height: 7px;
+    background: var(--team-color, #0f766e);
     pointer-events: none;
-    z-index: 30;
-}
-
-/* Member accent: thin line at top */
-.sc-team-linked::before,
-.sc-team-linked::after {
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 5px;
-    background: var(--team-color, #0f766e);
-}
-
-.sc-team-linked::after {
-    right: 12px;
-    width: 16px;
-    height: 5px;
-    background: linear-gradient(90deg, transparent 0%, var(--team-color, #0f766e) 60%, transparent 100%);
-}
-
-/* Team title accent: solid bar + half arrow at top */
-.sc-team-title {
-    position: relative;
-    border-color: transparent;
-    box-shadow: none;
-    overflow: hidden;
-}
-
-.sc-team-title::before,
-.sc-team-title::after {
-    display: block;
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-}
-
-.sc-team-title::before {
-    width: 100%;
-    height: 8px;
-    background: var(--team-color, #0f766e);
-}
-
-.sc-team-title::after {
-    left: auto;
-    right: 0;
-    width: 0;
-    height: 0;
-    border-top: 4px solid transparent;
-    border-bottom: 4px solid transparent;
-    border-left: 8px solid var(--team-color, #0f766e); /* half arrowhead */
+    z-index: 31;
 }
 
 /* Modals */


### PR DESCRIPTION
Closes #808.

## Problem
In the steering-committee team grid, title cards and member cards were equal-sized tiles flowing in one wrapping row. When the row wrapped, a member could land on a new line with no heading nearby — so it was ambiguous which sub-team it belonged to.

In the **before** shot below, *Sara Lil Middleton* wraps to the start of a new row and reads as part of "Ethics and Inclusion" (to her right), when she's actually the second member of "Sustainability & Strategy". Every title card is the same dark slate, so there's no way to tell teams apart across a wrap.

## Fix — connecting colour bars
Kept the dense single-flow mosaic (one reading order, even rows) but made each team read as **one connected run**: a coloured bar runs along the top of every tile in a team (title + members), bridges the gap to the next tile, and **breaks at the row edge / resumes on the next row** when a team wraps. A wrapped member keeps its team colour, so it's never orphaned. Each team gets a distinct colour; Steering & Guidance (no sub-teams) stay plain.

### Operations section — before vs after (worst case, 10 teams)
![Operations before/after](https://raw.githubusercontent.com/forrtproject/forrtproject.github.io/e000977493a67deb48e588741d0ed919eee25761/808/operations-before-after.png)

In *after*, Sara Lil Middleton's **purple** bar keeps her with Sustainability & Strategy, while "Ethics and Inclusion" is clearly the crimson team to her right.

<details><summary>Full page — after</summary>

![Full page after](https://raw.githubusercontent.com/forrtproject/forrtproject.github.io/e000977493a67deb48e588741d0ed919eee25761/808/full-after.png)

</details>
<details><summary>Full page — before</summary>

![Full page before](https://raw.githubusercontent.com/forrtproject/forrtproject.github.io/e000977493a67deb48e588741d0ed919eee25761/808/full-before.png)

</details>

(Screenshots live on the `pr-images` branch under `808/` for reproducibility — see its README for how they were generated.)

## Approach & alternatives
This was chosen after mocking up several alternatives (boxed panels, horizontal lanes, forced line breaks, a compact roster). The connecting-bar approach preserves the "one overarching team split into smaller teams" feel without boxes.

## Implementation notes
- Grouping and colours are now baked in at **generation time** (`generate_sc_profiles.py`), replacing the fragile runtime JS that re-fetched the source CSV and fuzzy-matched member names to re-order/colour cards. Net **−317 lines**.
- Card markup gains a `.sc-card-photo` wrapper (clips the image/zoom) so the connecting bar can overflow into the gap; a `.sc-cbar` element carries the bar.
- Heavy generator deps (pandas/requests/Pillow) are now imported optionally so the templates can be re-rendered without them.
- `index.md` was regenerated from the existing committed data (no network re-fetch), so the diff is purely the layout — all 32 members, names, roles, team titles and modals are unchanged. The generator still rebuilds correctly from the two Google Sheets sources (the data/merge path is unchanged; only card rendering moved into shared helpers, verified to reproduce the committed markup byte-for-byte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)