### PR TITLE
Fix steering-committee card misalignment (drop 1px border) (#808)

### DIFF
--- a/static/css/steering-committee.css
+++ b/static/css/steering-committee.css
@@ -148,7 +148,11 @@ article.article .article-container .article-title {
     /* overflow stays visible so the connecting bar can reach into the gap; the photo
        itself is clipped by .sc-card-photo. */
     overflow: visible;
-    border: 1px solid transparent;
+    /* No border: title cards have border:0, and with box-sizing:border-box a 1px border
+       here would push the absolutely-positioned photo and connecting bar 1px inward, so
+       photo cards would sit lower/smaller than title cards and the top bars wouldn't line
+       up into one continuous row. */
+    border: 0;
     /* Portrait aspect ratio 2:3 */
     aspect-ratio: 2/3;
     transition: box-shadow 0.3s ease;


### PR DESCRIPTION
Follow-up to #815. On the live page the member photo cards rendered slightly **shorter and lower** than the team title cards, with a gap above each photo, and the colored team header bars did not line up into one continuous row.

## Root cause
`.sc-card` (member cards) had `border: 1px solid transparent`; `.sc-title-card` had `border: 0`. With `box-sizing: border-box` both cards measure the **same outer size** (so `getBoundingClientRect` reports them as aligned), but their absolutely-positioned children — `.sc-card-photo`, `.sc-card-img`, `.sc-cbar` — are painted from the **padding** box, 1px inside the border. So every photo and header bar on a member card sat 1px down and 2px smaller than on the title cards. On Retina that's 2px, and against the full-bleed title cards it reads as a clear height gap and a broken header line.

## Fix
Remove the border from `.sc-card` (one line). The padding box now equals the border box, so photos fill flush to the top and the header bars align continuously across each team.

Verified in a local Hugo build (real academic theme) at 1× and 2×: title cards, photo cards, and all header bars share the same top edge; photos fill to the card top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)