### PR TITLE
Add Best-Practice Guidelines for Psychology to the Nexus

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -161,6 +161,12 @@
     parent = "nexus"
 
   [[main]]
+    name = "Best-Practice Guidelines for Psychology"
+    url = "https://forrt.org/best-practices-psychology/"
+    weight = 32.5
+    parent = "nexus"
+
+  [[main]]
     name = "Citation Politics"
     url = "/citation-politics"
     weight = 33

--- a/content/nexus/intro-nexus.md
+++ b/content/nexus/intro-nexus.md
@@ -62,6 +62,7 @@ FORRT's e-learning platform (or Nexus) is a hub for community-driven initiatives
 
 * [About Educational Nexus](/nexus)
 * [Adopting Principled Education](/adopting)
+* [Best-Practice Guidelines for Psychology](https://forrt.org/best-practices-psychology/)
 * [Citation Politics](/citation-politics)
 * [Clusters](/clusters)
 * [Curated Resources](/resources)


### PR DESCRIPTION
Adds the **Best-Practice Guidelines for Psychology** project to the Educational Nexus.

- Adds an entry to the Nexus dropdown **menu** (`config/_default/menus.toml`), alphabetically placed between *Adopting Principled Education* and *Citation Politics* (weight 32.5).
- Adds the matching bullet to the **"Elements of the Nexus include"** list on the Nexus page (`content/nexus/intro-nexus.md`), keeping the menu and page list in sync.

Links to https://forrt.org/best-practices-psychology/ (live, HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)