### PR TITLE
Remove redundant Ombudsman->Ombuds override from steering-committee generator

### DIFF
--- a/scripts/generate_sc_profiles.py
+++ b/scripts/generate_sc_profiles.py
@@ -275,17 +275,6 @@ def sanitize_filename(name):
     name = re.sub(r'\\s+', '-', name)
     return name
 
-# Role labels the sheet uses that we want to display differently on the site
-# (e.g. to keep terminology gender-neutral and consistent with other pages).
-ROLE_LABEL_OVERRIDES = {
-    "Ombudsman": "Ombuds",
-}
-
-def normalize_role_label(role):
-    if not role or (pd is not None and pd.isna(role)):
-        return role
-    return ROLE_LABEL_OVERRIDES.get(str(role).strip(), role)
-
 def get_initials(name):
     parts = name.split()
     if len(parts) >= 2:
@@ -572,7 +561,7 @@ def main():
                     img_content = f'<div class="sc-placeholder">{member["initials"]}</div>'
 
                 cards_html += render_member_card(
-                    render_id, member["name"], normalize_role_label(member["role"]), img_content,
+                    render_id, member["name"], member["role"], img_content,
                     color=team_color,
                     is_last=(member_index == len(members) - 1),
                 )
@@ -587,7 +576,7 @@ def main():
                 modals_html += MODAL_TEMPLATE.format(
                     id=render_id,
                     name=member["name"],
-                    role=normalize_role_label(member["role_title"] or member["role"]),
+                    role=member["role_title"] or member["role"],
                     bio=html.escape(member["bio"] or "Bio coming soon."),
                     img_content_large=img_content_large,
                     social_links=generate_social_links(member)


### PR DESCRIPTION
## Summary
Follow-up to #824. That PR fixed the "Ombuds" role label on the Steering Committee page by adding a `ROLE_LABEL_OVERRIDES` workaround in `scripts/generate_sc_profiles.py`, which silently rewrote whatever the roster sheet said. That's the wrong layer for a data fix — it would have quietly diverged from the sheet forever.

The actual "Ombudsman" text was fixed at the source instead: the Role/Team/Role Title columns for Thomas Rhys Evans's row were corrected directly in the live "FORRT Steering Committee | Members" Google Sheet. This PR removes the now-redundant script-side override, so the generator just reflects whatever the sheet says (which is now the label the site already shows). The genuine code fix from #824 — giving each person-role occurrence in the sheet a unique DOM id, so a person with two roles gets two independently-openable modals — is untouched.

## Test plan
- [x] `hugo --minify` build succeeds with no errors
- [x] `codespell` clean on the changed file
- [x] Confirmed the live roster sheet already reads "Ombuds" (not "Ombudsman"), so this is a no-op for the rendered page — pure code cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)