### PR TITLE
Announcements: fix card overflow, add scheduling & working removal (#830)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -169,6 +169,15 @@ jobs:
         run: |
           if [ -f .announcements/announcements.tar.gz ]; then
             echo "📥 Applying announcement posts from artifact..."
+            # The artifact holds the full current set of announcements. Replace
+            # the committed seed bundles entirely so a post removed from the
+            # sheet (or set to Show = "no") is taken down rather than lingering
+            # from the checkout — tar extraction adds files but never deletes
+            # ones the archive no longer contains. The section index and any
+            # non-bundle files are preserved. Only runs when we actually have an
+            # artifact to apply, so announcements are never wiped without a
+            # replacement.
+            find content/post -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
             tar xzf .announcements/announcements.tar.gz
           else
             echo "::warning::announcements artifact present but tarball missing; skipping."

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -3028,6 +3028,7 @@ h1.clusters-site-heading.clusters-hub-page__title {
   gap: 1.6rem;
 }
 .announcement-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   background: #fff;
@@ -3039,6 +3040,19 @@ h1.clusters-site-heading.clusters-hub-page__title {
   color: inherit;
   text-decoration: none;
   height: 100%;
+}
+/* Whole-card click target: the title link stretches over the card via an
+   overlay. Keeping the card an <article> (not an <a>) lets summary links
+   nest without breaking the HTML. */
+.announcement-card .ac-link {
+  color: inherit;
+  text-decoration: none;
+}
+.announcement-card .ac-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
 }
 .announcement-card:hover {
   transform: translateY(-3px);

--- a/layouts/partials/announcement_card.html
+++ b/layouts/partials/announcement_card.html
@@ -1,8 +1,15 @@
-{{/* Renders one announcement card. Context (.) is the post page. */}}
+{{/* Renders one announcement card. Context (.) is the post page.
+     The card is an <article>, not an <a>: the summary may contain links
+     (e.g. a Markdown link), and nesting an <a> inside a card-wide <a> is
+     invalid HTML — the browser closes the outer anchor early and ejects the
+     body out of the card. Instead the title is a "stretched link" whose
+     ::after overlay makes the whole card navigate to the post (see
+     custom.scss); links inside the summary still display, but the card
+     overlay catches the click, so the whole card leads to the post. */}}
 {{ $post := . }}
 {{ $img := ($post.Resources.ByType "image").GetMatch "*featured*" }}
 {{ $cat := "" }}{{ with $post.Params.categories }}{{ $cat = index . 0 }}{{ end }}
-<a class="announcement-card{{ if not $img }} no-image{{ end }}" href="{{ $post.RelPermalink }}">
+<article class="announcement-card{{ if not $img }} no-image{{ end }}">
   {{ with $img }}
   <div class="ac-thumb">
     <img loading="lazy" src="{{ (.Fill "640x360 Center").RelPermalink }}" alt="">
@@ -13,10 +20,10 @@
       {{ with $cat }}<span class="ac-cat {{ lower . }}">{{ . }}</span>{{ end }}
       <span class="ac-date">{{ $post.Date.Format "Jan 2006" }}</span>
     </div>
-    <h3>{{ $post.Title }}</h3>
+    <h3><a class="ac-link" href="{{ $post.RelPermalink }}">{{ $post.Title }}</a></h3>
     {{/* Render the rendered-markdown summary as HTML so formatting (bold, links)
          and typographic entities (’, —) display correctly; CSS clamps the height. */}}
     <div class="ac-summary">{{ $post.Summary }}</div>
     <span class="ac-more">Read more ›</span>
   </div>
-</a>
+</article>

--- a/scripts/create_announcements.R
+++ b/scripts/create_announcements.R
@@ -197,5 +197,16 @@ create_post <- function(row) {
   get_image(row["imageUrl"], slug_folder)
 }
 
+# Rebuild content/post from the publishable set so the sheet is the single
+# source of truth. Removing a row — or setting Show to "no", or scheduling it
+# into the future — drops it from filtered_data, and clearing the old bundles
+# here takes the announcement down instead of leaving a stale post behind.
+# Only the per-post page bundles are removed; the section index
+# (content/post/_index.md) and any other files are preserved. deploy.yaml does
+# the same clear before unpacking this artifact, because tar extraction adds
+# files but never deletes ones the archive no longer contains.
+post_dirs <- list.dirs("content/post", recursive = FALSE)
+if (length(post_dirs) > 0) unlink(post_dirs, recursive = TRUE)
+
 # Apply the function to each row of the filtered data
 apply(filtered_data, 1, function(row) create_post(as.list(row)))

--- a/scripts/create_announcements.R
+++ b/scripts/create_announcements.R
@@ -1,10 +1,15 @@
 # Generate FORRT announcement posts from the "FORRT Announcements" Google Sheet.
 #
 # Adapted from the contact-research-network webpage pipeline. Reads a publicly
-# shared Google Sheet (no auth via gs4_deauth), and for every row with
-# Show == "yes" writes a Hugo page bundle to content/post/<Slug>/index.md plus an
-# optional featured image. A hash of the sheet is cached so unchanged data is a
-# no-op. Run from the repo root: Rscript scripts/create_announcements.R
+# shared Google Sheet (no auth via gs4_deauth), and for every row that is
+# Show == "yes" AND dated today or earlier writes a Hugo page bundle to
+# content/post/<Slug>/index.md plus an optional featured image. A hash of the
+# publishable set is cached so an unchanged set is a no-op.
+# Run from the repo root: Rscript scripts/create_announcements.R
+#
+# Scheduling: give a row a future Date to stage it. It stays hidden until that
+# date, then the hourly workflow publishes it automatically (see the hashing
+# note below). No sheet edit is needed on the day it goes live.
 #
 # Sheet columns: Slug, Title, Description, imageUrl, webUrl, LinkText, Date,
 #                Author, Category, Show
@@ -19,35 +24,60 @@ library(digest)
 # Define file path for hash
 hash_file <- "gs_announcement_hash.txt"
 
-# Authenticate and read the Google Sheet (public, so read without auth)
+# Authenticate and read the Google Sheet (public, so read without auth).
+# Read the data tab by name so re-ordering tabs (e.g. adding an instructions
+# tab) can never feed the wrong sheet into the pipeline.
 sheet_url <- "https://docs.google.com/spreadsheets/d/1jVJyxdpArAGBbWhmdlbXfEhZRrIHl8JFkRrZGWkvOcI/edit"
 googlesheets4::gs4_deauth()
-data <- read_sheet(sheet_url)
+data <- read_sheet(sheet_url, sheet = "Sheet1")
 
 # Trim any stray whitespace from column names so lookups by name are robust.
 names(data) <- trimws(names(data))
 
-# Compute new hash
-new_hash <- digest(data, algo = "md5")
+# --- Scheduling: only publish rows whose Date has arrived -------------------
+# A row goes live when Show == "yes" AND its Date is today or earlier (UTC, the
+# CI runner's clock). A future Date keeps the announcement staged: it is neither
+# written nor counted in the change hash below, so nothing is published until
+# the date arrives. A blank/unparseable Date is treated as "publish now" so a
+# missing date never silently hides a post.
+to_date <- function(x) {
+  x <- trimws(as.character(x))
+  if (length(x) == 0 || is.na(x) || x == "") return(as.Date(NA))
+  if (grepl("^[0-9]+(\\.[0-9]+)?$", x)) {   # Google Sheets numeric date serial
+    return(as.Date(as.numeric(x), origin = "1899-12-30"))
+  }
+  suppressWarnings(as.Date(x))
+}
+row_dates <- do.call(c, lapply(data$Date, to_date))
+today     <- Sys.Date()
+is_shown  <- tolower(trimws(as.character(data$Show))) == "yes"
+is_future <- !is.na(row_dates) & row_dates > today
+keep      <- is_shown & !is_future
+keep[is.na(keep)] <- FALSE
+filtered_data <- data[keep, ]
+
+# Compute the change hash over the *publishable* set rather than the raw sheet.
+# This is what makes scheduling work: when a staged post's Date arrives it
+# enters this set and the hash changes, so the hourly workflow redeploys and the
+# post appears — even though the sheet itself was not edited. Edits to future or
+# hidden rows leave the set unchanged and so do not trigger a needless deploy.
+new_hash <- digest(filtered_data, algo = "md5")
 
 # Read old hash if exists
 old_hash <- if (file.exists(hash_file)) readLines(hash_file) else NULL
 
-# Abort if data hasn't changed
+# Abort if the publishable set hasn't changed
 if (!is.null(old_hash) && new_hash == old_hash) {
   if (!interactive()) {
-    message("Data hasn't changed. Exiting.")
+    message("Publishable announcements unchanged. Exiting.")
     quit(save = "no", status = 0)
   } else {
-    stop("Data hasn't changed. Exiting.")
+    stop("Publishable announcements unchanged. Exiting.")
   }
 }
 
 # Save new hash
 writeLines(new_hash, hash_file)
-
-# Filter for show = yes
-filtered_data <- data[tolower(trimws(data$Show)) == "yes", ]
 
 # Extract ID from Google Drive URL
 extract_id <- function(url) {


### PR DESCRIPTION
Closes #830.

Addresses all of issue #830: the Nowhere Lab card breaking out of its box, plus scheduling future-dated announcements and (as a corollary) making removal actually work.

## 1. Display bug — card breaking out of its box
The card wrapped everything in one `<a>`. Nowhere Lab's summary contains a Markdown link, producing an `<a>` nested inside the card-wide `<a>` — invalid HTML. The browser's parser closes the outer anchor early and ejects the card body outside the box, so the card rendered empty with stray text below the grid. Any announcement with a link in its summary would break identically.

Fix: the card is now an `<article>` and the title is a "stretched link" whose overlay keeps the whole card clickable through to the post. No anchor is nested inside another.

Verified in a real browser (Hugo 0.158.0): 0 broken anchors in the parsed DOM; clean, contained card on `/post/` and the homepage widget, desktop and mobile.

## 2. Scheduling — publish on a future date
Announcements are generated hourly from the Google Sheet, but only when the sheet's content hash changes. A future-dated row deployed immediately (Hugo then hid it as future-dated), and because the sheet didn't change on its target date, no rebuild ever fired — so it never appeared.

Fix: publish a row only when `Show = "yes"` **and** its `Date` is today or earlier, and compute the change hash over the *publishable* set rather than the raw sheet. A staged post enters the set on its date, the hash changes, and the hourly workflow republishes it automatically — no sheet edit needed. A blank/unparseable date is treated as "publish now" so a missing date never silently hides a post. The data tab is also now read by name (`Sheet1`) rather than by position.

Verified end-to-end against the live sheet: the current 11 posts still generate, the hash is stable across runs, a row dated tomorrow is excluded (hash unchanged), and the same row dated yesterday is included (hash changes).

## 3. Removal — `Show = "no"` now takes a post down
Setting `Show = "no"` (or deleting a row) previously left the announcement live. The sheet was never the full source of truth: the create job tar'd its whole `content/post` — including committed seed bundles the sheet no longer listed — and the deploy job unpacked that artifact *over* its checkout, and tar extraction adds files but never deletes ones the archive dropped. So a removed post survived from the committed seed.

Fix: rebuild `content/post` from the publishable set in both places. The generator clears the old page bundles before writing the current set, so the artifact holds exactly what should be live; the deploy clears the seed bundles before unpacking that artifact (guarded so it only runs when an artifact is present — announcements are never wiped without a replacement). `_index.md` and non-bundle files are preserved throughout.

Verified: a stale post bundle absent from the sheet is removed by the generator while `_index.md` and other files survive; the deploy clear removes only the per-post bundle directories.

## 4. Instructions tab (Google Sheet)
Added a `How to add announcements` tab to the source sheet (at index 1, so `Sheet1` stays first and the current pipeline is unaffected). It covers the quick-start flow, every column, scheduling, removal, drafting, and gotchas.

## Notes for review
- **Scheduling and removal take effect only once this merges and the production deploy runs the new `create_announcements.R` + `deploy.yaml`.** The instructions tab is already live in the sheet describing both as working, so merging promptly avoids a window where a maintainer sets `Show=no`/a future date and sees nothing happen.
- The artifact is now authoritative and clears the committed `content/post` seed on each deploy, so that seed will drift from the sheet. It only surfaces if the announcements artifact expires (90-day retention) and a deploy falls back to the stale seed, which could briefly resurrect a removed post. Low risk given the monthly-newsletter cadence keeps the artifact fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)