### PR TITLE
Make announcements workflow resilient to r2u mirror timeouts

### DIFF
--- a/.github/workflows/create_announcements.yml
+++ b/.github/workflows/create_announcements.yml
@@ -64,7 +64,26 @@ jobs:
         uses: eddelbuettel/github-actions/r2u-setup@master
 
       - name: Install R package dependencies
-        run: Rscript -e 'install.packages(c("googlesheets4", "httr", "digest"))'
+        # install.packages here runs through r2u/bspm, which fetches .debs via apt.
+        # The r2u mirror occasionally times out, so retry a few times before failing —
+        # a transient blip clears on the next attempt. We verify the packages are
+        # actually present (install.packages only warns, it does not error, on a
+        # partial failure) so the retry can't be fooled into a false success.
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::install R packages (attempt $attempt)"
+            Rscript -e '
+              pkgs <- c("googlesheets4", "httr", "digest")
+              install.packages(pkgs)
+              missing <- pkgs[!pkgs %in% rownames(installed.packages())]
+              if (length(missing)) { message("Still missing: ", paste(missing, collapse = ", ")); quit(status = 1) }
+            ' && { echo "::endgroup::"; echo "R packages installed on attempt $attempt."; exit 0; }
+            echo "::endgroup::"
+            echo "Attempt $attempt failed; retrying in 30s..."
+            sleep 30
+          done
+          echo "All 3 attempts to install R packages failed." >&2
+          exit 1
 
       - name: Generate announcement posts
         id: gen

--- a/.github/workflows/create_announcements.yml
+++ b/.github/workflows/create_announcements.yml
@@ -21,7 +21,7 @@ name: Create announcements
 
 on:
   schedule:
-    - cron: '15 * * * *'   # hourly (offset to balance runner load)
+    - cron: '15 */2 * * *'   # every 2 hours (offset to balance runner load)
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

The hourly **Create announcements** workflow intermittently fails at the *Install R package dependencies* step with:

```
Could not connect to r2u.stat.illinois.edu:443, connection timed out
Error: Execution halted
```

`install.packages` runs through r2u/bspm, which fetches `.deb`s via `apt`. When the r2u binary mirror briefly times out during `apt update`, the whole run fails — even though nothing is wrong and the next run succeeds. This is a transient network flake, not a code problem.

## Changes

- **Retry the install step up to 3×** (30s apart) and verify the packages are actually present before treating it as success (`install.packages` only warns, it doesn't error, on a partial failure). A one-off mirror blip now clears on retry instead of failing the run.
- **Drop the schedule from hourly to every 2 hours** (`15 */2 * * *`) — announcements are not time-critical to the hour, and this halves the runner load and the exposure to mirror flakiness.

The workflow is self-healing (change detection is artifact-based), so a fully failed run is already picked up on the next schedule with no data loss; the retry just stops isolated timeouts from surfacing as failures.

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)