### PR TITLE
Add CITATION.cff + citation guidance with FORRT-owned OSF DOI (#326)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,10 @@ title: >-
   FORRT — Framework for Open and Reproducible Research
   Training (forrt.org)
 message: >-
-  If you use FORRT resources or refer to the FORRT website,
+  If you refer to the FORRT website,
   please cite it using the metadata from this file.
+  For citing specific projects, please refer to the
+  respective project pages and their citation information.
 type: software
 authors:
   - name: >-
@@ -20,11 +22,9 @@ identifiers:
     description: >-
       FORRT-owned DOI for the FORRT website, registered on OSF.
 abstract: >-
-  FORRT (Framework for Open and Reproducible Research
-  Training) is a community-led didactic and pedagogical
-  infrastructure supporting open and reproducible research
-  training in higher education. This repository contains the
-  source code and content of the FORRT website, forrt.org.
+  FORRT is a community committed to advancing open scholarship through
+  education, meta-research, community building, training and advocacy. 
+  This repository contains the source code and content of the FORRT website, forrt.org.
 keywords:
   - open scholarship
   - reproducibility

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,13 +13,12 @@ authors:
     website: 'https://forrt.org'
 repository-code: 'https://github.com/forrtproject/forrtproject.github.io'
 url: 'https://forrt.org'
-# Once the repository is archived on Zenodo (see the GitHub–Zenodo
-# integration), add the concept DOI that always points to the latest
-# version by uncommenting the block below:
-# identifiers:
-#   - type: doi
-#     value: 10.5281/zenodo.XXXXXXX
-#     description: The concept DOI representing all versions.
+doi: 10.17605/OSF.IO/QBCJ3
+identifiers:
+  - type: doi
+    value: 10.17605/OSF.IO/QBCJ3
+    description: >-
+      FORRT-owned DOI for the FORRT website, registered on OSF.
 abstract: >-
   FORRT (Framework for Open and Reproducible Research
   Training) is a community-led didactic and pedagogical

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+title: >-
+  FORRT — Framework for Open and Reproducible Research
+  Training (forrt.org)
+message: >-
+  If you use FORRT resources or refer to the FORRT website,
+  please cite it using the metadata from this file.
+type: software
+authors:
+  - name: >-
+      FORRT — Framework for Open and Reproducible Research
+      Training
+    website: 'https://forrt.org'
+repository-code: 'https://github.com/forrtproject/forrtproject.github.io'
+url: 'https://forrt.org'
+# Once the repository is archived on Zenodo (see the GitHub–Zenodo
+# integration), add the concept DOI that always points to the latest
+# version by uncommenting the block below:
+# identifiers:
+#   - type: doi
+#     value: 10.5281/zenodo.XXXXXXX
+#     description: The concept DOI representing all versions.
+abstract: >-
+  FORRT (Framework for Open and Reproducible Research
+  Training) is a community-led didactic and pedagogical
+  infrastructure supporting open and reproducible research
+  training in higher education. This repository contains the
+  source code and content of the FORRT website, forrt.org.
+keywords:
+  - open scholarship
+  - reproducibility
+  - open science
+  - research training
+  - pedagogy
+  - higher education
+  - metascience
+license: CC-BY-NC-SA-4.0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You can find [open issues here](https://github.com/forrtproject/forrtproject.git
 
 If you use FORRT resources or refer to the FORRT website in your work, please cite us.
 
+The FORRT website has a persistent DOI: [**10.17605/OSF.IO/QBCJ3**](https://doi.org/10.17605/OSF.IO/QBCJ3) (FORRT-owned, registered on OSF).
+
 Machine-readable citation metadata is provided in [`CITATION.cff`](CITATION.cff). On GitHub, you can obtain a formatted citation (APA or BibTeX) via the **"Cite this repository"** button in the sidebar of the [repository page](https://github.com/forrtproject/forrtproject.github.io).
 
 To cite a specific FORRT initiative, resource, or publication, please use the citation details provided on its dedicated page at [forrt.org](https://forrt.org). Many FORRT outputs (e.g. the Glossary, Summaries of Open Scholarship, and Lesson Banks) have their own preferred citations and persistent identifiers.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ You can find [open issues here](https://github.com/forrtproject/forrtproject.git
 
 ---
 
+## How to Cite
+
+If you use FORRT resources or refer to the FORRT website in your work, please cite us.
+
+Machine-readable citation metadata is provided in [`CITATION.cff`](CITATION.cff). On GitHub, you can obtain a formatted citation (APA or BibTeX) via the **"Cite this repository"** button in the sidebar of the [repository page](https://github.com/forrtproject/forrtproject.github.io).
+
+To cite a specific FORRT initiative, resource, or publication, please use the citation details provided on its dedicated page at [forrt.org](https://forrt.org). Many FORRT outputs (e.g. the Glossary, Summaries of Open Scholarship, and Lesson Banks) have their own preferred citations and persistent identifiers.
+
+---
+
 ## License
 
 <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" /></a>


### PR DESCRIPTION
Closes #326.

Makes the repository citable and FAIR-aligned.

## What's included
- **`CITATION.cff`** — machine-readable citation metadata (CFF 1.2.0, validated against the schema with `cffconvert`). GitHub renders this as a "Cite this repository" button offering APA/BibTeX. FORRT is credited as the authoring community/entity.
- **Persistent DOI** — the FORRT website's **FORRT-owned OSF DOI, [10.17605/OSF.IO/QBCJ3](https://doi.org/10.17605/OSF.IO/QBCJ3)** (OSF project "FORRT Website"), is set in both the `CITATION.cff` (`doi:` + `identifiers:`) and the README.
- **README "How to Cite" section** — surfaces the DOI, points to the CFF-driven citation, and notes that individual FORRT resources have their own preferred citations on forrt.org.

## Why OSF rather than Zenodo
OSF keeps the DOI under FORRT's own account rather than depending on an individual's GitHub–Zenodo OAuth. Zenodo remains a future option if automatic per-release versioned DOIs (with a single concept DOI) are wanted — OSF doesn't provide that. Rationale recorded in the issue thread.

## Notes for review
- Author is the FORRT organizational entity (`name:`) rather than named individuals — easy to switch to a contributor list if preferred.
- DOI verified to resolve (302 → osf.io/qbcj3) and is registered on the OSF node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)