### PR TITLE
Add social sharing preview images for Impact, AWoP, Teaching Open Science, and Contributor Analyses pages

### DIFF
--- a/content/adopting/index.md
+++ b/content/adopting/index.md
@@ -3,4 +3,6 @@
 type = "widget_page"
 headless = false  # Homepage is headless, other widget pages are not.
 title = "Adopting Open Science"
+sharing_image = "img/ape.webp"
+sharing_image_alt = "Adopting Principled Education — commitments to integrate, teach, share, and address open science practices"
 +++

--- a/content/awop/index.md
+++ b/content/awop/index.md
@@ -4,4 +4,6 @@ type = "widget_page"
 headless = false  # Homepage is headless, other widget pages are not.
 title = "Academic Wheel of Privilege (AWoP)"
 # url = "/awop"
+sharing_image_resource = "AWOP.webp"
+sharing_image_alt = "The Academic Wheel of Privilege — a tool for authorship order decisions"
 +++

--- a/content/citation-politics/_index.md
+++ b/content/citation-politics/_index.md
@@ -2,6 +2,8 @@
 summary: "Citations can be thought of as a currency in the academy, where more citations equals more prestige. While the system assumes a meritocracy—where higher citation counts supposedly indicate higher quality because a work is deemed valuable and legitimate by peers—this perspective ignores inherent biases and systemic inequalities."
 type: citation_politics
 url: "/citation-politics/"
+sharing_image: "img/citation-politics-toolkit.webp"
+sharing_image_alt: "Towards Citational Justice Across the Whole Research Cycle — a wheel of citation politics tools and practices for planning, project, paper, and publication stages"
 ---
 
 <div style="text-align: center; margin: 1rem 0;">

--- a/content/citation-politics/toolkit/index.md
+++ b/content/citation-politics/toolkit/index.md
@@ -1,6 +1,8 @@
 ---
 type: citation_politics
 url: "/citation-politics/toolkit/"
+sharing_image: "img/citation-politics-toolkit.webp"
+sharing_image_alt: "Towards Citational Justice Across the Whole Research Cycle — a wheel of citation politics tools and practices for planning, project, paper, and publication stages"
 ---
 
 {{< citation-politics-toolkit >}}

--- a/content/contributor-analysis/index.md
+++ b/content/contributor-analysis/index.md
@@ -7,6 +7,8 @@ output:
     preserve_yaml: true
     toc: false
 type: contributors_analysis
+sharing_image_resource: "treemap-plot-1.png"
+sharing_image_alt: "Treemap showing the share of FORRT contributors by number of projects they contributed to"
 ---
 
 As of 10 June 2026, FORRT has a total of 109 completed or ongoing

--- a/content/impact/index.md
+++ b/content/impact/index.md
@@ -3,5 +3,7 @@
 type = "widget_page"
 headless = false  # Homepage is headless, other widget pages are not.
 title = "Impact"
+sharing_image_resource = "impacts-map.webp"
+sharing_image_alt = "World map showing the number of FORRT contributors and collaborators by country"
 +++
 

--- a/content/just_os_chatbot/index.md
+++ b/content/just_os_chatbot/index.md
@@ -3,4 +3,6 @@
 type = "widget_page"
 headless = false  # Homepage is headless, other widget pages are not.
 title = "JUST-OS Chatbot"
+sharing_image = "img/just_os_icon.webp"
+sharing_image_alt = "JUST-OS chatbot mascot logo"
 +++

--- a/content/nowherelab/_index.md
+++ b/content/nowherelab/_index.md
@@ -2,6 +2,8 @@
 title: Nowhere Lab
 subtitle: An online lab community for those without a lab
 date: 2026-04-28
+sharing_image: "img/nowherelab-logo.png"
+sharing_image_alt: "Nowhere Lab logo"
 ---
 
 <div style="min-height:458px; margin-bottom: 2rem;">

--- a/content/teaching_os/index.md
+++ b/content/teaching_os/index.md
@@ -4,6 +4,8 @@ type = "widget_page"
 headless = false  # Homepage is headless, other widget pages are not.
 title="Teaching Open Science"
 # url = "/feedback"
+sharing_image_resource = "PostEdu1.webp"
+sharing_image_alt = "POST-Edu: Promoting Open Science Teaching, a positive, inclusive and participatory program for educators"
 +++
 
 ****

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -211,6 +211,14 @@
     {{ $og_image = $share_res.Permalink }}
     {{ $og_image_width = $share_res.Width }}
     {{ $og_image_height = $share_res.Height }}
+  {{ else if .Params.sharing_image }}
+    {{/* Path relative to `static/`, e.g. `sharing_image: "img/my-image.webp"` - for pages that aren't
+         Hugo page bundles and so can't use `sharing_image_resource`. */}}
+    {{ $og_image = .Params.sharing_image | absURL }}
+    {{ with images.Config (printf "/static/%s" .Params.sharing_image) }}
+      {{ $og_image_width = .Width }}
+      {{ $og_image_height = .Height }}
+    {{ end }}
   {{ else if .Params.header.image }}
     {{ $og_image = printf "%s/%s" $media_dir .Params.header.image | absURL }}
   {{ else if site.Params.sharing_image }}


### PR DESCRIPTION
## Description
Several FORRT pages had unused images already sitting in their content bundles (page graphics, charts, logos) but were falling back to the generic FORRT banner for social media link previews, since nothing pointed the sharing-image logic at them.

Wired up the existing `sharing_image_resource` front-matter field (added in #696/#720) to use each page's own image instead:
- `/impact/` → `impacts-map.webp` (world map of contributors)
- `/awop/` → `AWOP.webp` (Academic Wheel of Privilege diagram)
- `/teaching_os/` → `PostEdu1.webp` (POST-Edu program banner)
- /nowherelab/, /just_os_chatbot/, /citation-politics/, and /adopting/. also covered using the existing images

Each also gets a `sharing_image_alt` for accessibility/screen readers.

No new images were created — this only wires up existing files that were already in each page's bundle.

Fixes #701

## Type of Change
- [x] Content/documentation update

## Testing
- [x] Tested locally
- [x] Previewed on [staging.forrt.org](https://staging.forrt.org/)

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
the rest of the pages that :
No image asset exists at all (would need a new graphic to be created):

/disciplines/ — the new "Open Research Across Disciplines" 

