### PR TITLE
Fix 404 redirects appending 'undefined' (e.g. /replication_handbook)

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -53,7 +53,10 @@
     if (match) {
       var target = redirects[i].target;
       for (var j = 1; j < match.length; j++) {
-        target = target.replace('$' + j, match[j]);
+        // Optional groups are undefined when they do not participate in the
+        // match (e.g. /FReD with no trailing path), which would otherwise
+        // append the literal string "undefined" to the target.
+        target = target.replace('$' + j, match[j] || '');
       }
       window.location.replace(target);
       return;


### PR DESCRIPTION
`https://forrt.org/replication_handbook` redirects to `https://forrt.org/replication-handbookundefined` instead of `/replication-handbook`.

**Cause.** In `layouts/404.html`, the rename redirects use an optional capture group: `/^\/replication_handbook(\/.*)?$/` → `/replication-handbook$1`. When the path has no sub-path, the group does not participate in the match, so `match[1]` is `undefined`, and `target.replace('$1', undefined)` stringifies it, producing `...handbookundefined`.

**Fix.** One line: substitute `match[j] || ''`.

This affected all eight rename redirects, not just the handbook: `/FReD` → `/fredundefined`, `/TenureRun` → `/tenure-runundefined`, `/flora_zotero` → `/flora-zoteroundefined`, and so on. Paths that did carry a sub-path (`/replication_handbook/legacy/`) were always fine, which is why it went unnoticed.

Verified by running the redirect table from the patched file through node:

```
/replication_handbook          -> /replication-handbook
/replication_handbook/         -> /replication-handbook/
/replication_handbook/legacy/  -> /replication-handbook/legacy/
/FReD                          -> /fred
/FReD-apps/x                   -> /fred-apps/x
/TenureRun                     -> /tenure-run
/curated_resources             -> /resources/
/glossary/english/foo          -> /glossary/english/
/nonexistent                   -> null (no redirect)
```