### PR TITLE
SEO: templates, config, and the generators that feed them

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -47,8 +47,37 @@ local_business_type = ""
 # Enter an organization or project name. Defaults to the site title from `config.toml`.
 org_name = "Framework for Open and Reproducible Research Training"
 
+# Short site name, used as the `<title>` suffix on every non-home page and as
+# `alternateName` in the Organization structured data. Keep it short: search
+# engines truncate titles at roughly 60 characters, so spelling out `org_name`
+# on every page pushes the page's own title out of the visible result.
+short_title = "FORRT"
+
 # Description for social sharing and search engines. If undefined, superuser role is used in place.
 description = "Integrating open and reproducible science into higher education"
+
+# Official FORRT profiles elsewhere, emitted as `sameAs` in the Organization
+# structured data so search engines can tie this site to them as one entity.
+# Keep in sync with `layouts/shortcodes/social-media.html`.
+social_profiles = [
+  "https://bsky.app/profile/forrt.bsky.social",
+  "https://mastodon.social/@FORRT",
+  "https://linkedin.com/company/forrt",
+  "https://github.com/forrtproject",
+  "https://osf.io/forrt",
+  "https://youtube.com/@forrtproject9995",
+  "https://instagram.com/forrtproject",
+  "https://facebook.com/forrtproject",
+]
+
+# Minimum number of entries a `tags` term needs before its archive page is left
+# open to search engines. Tags come from free text on curated resources, and
+# roughly three quarters of them are used exactly once, so without a floor the
+# site publishes ~1,500 near-empty archives that mostly restate a single card.
+# Terms below the floor are still browsable and still pass link equity — they
+# are marked `noindex, follow` and kept out of the sitemap. Set to 0 to index
+# every term again.
+tag_index_min_pages = 5
 
 ############################
 ## Site Features
@@ -288,6 +317,19 @@ plugins_js  = []
   engine = 2
   api_key = ""
   zoom = 15
+
+############################
+## Content Management System
+############################
+[cms]
+  # Loads the Netlify Identity widget on the home page, as a render-blocking
+  # script. Turned off because it cannot work here: `static/admin/config.yml`
+  # uses the `git-gateway` backend, which authenticates through Netlify
+  # Identity, but the site is deployed to GitHub Pages (see
+  # `.github/workflows/deploy.yaml`) and `netlify.toml` is retained only as
+  # `netlify.toml.deprecated`. Set back to `true` if the admin panel is ever
+  # moved to a backend that needs the widget.
+  netlify_cms = false
 
 ############################
 ## Marketing

--- a/content/glossary/_create_glossaries.py
+++ b/content/glossary/_create_glossaries.py
@@ -249,6 +249,12 @@ for language_code in languages_to_process:
 
         entry = {
             "type": "glossary",
+            # The English name of the concept, emitted for every language. The
+            # five glossaries are parallel content directories rather than Hugo
+            # language sites, so `.Translations` is empty for them; grouping on
+            # `en_title` is what lets `partials/functions/glossary_translations.html`
+            # reconstruct the translation sets and emit hreflang.
+            "en_title": en_title,
             "title": title,
             "sort_key": sort_key_for_language(title, language_code),
             "definition": definition,

--- a/content/resources/resource.py
+++ b/content/resources/resource.py
@@ -52,7 +52,14 @@ def split_cells(df):
     df['education_level'] = [[y.strip() for y in x.split(',')] for x in df['education_level'].values]
     df['subject_areas'] = [[y.strip() for y in x.split(',')] for x in df['subject_areas'].values]
     df['FORRT_clusters'] = [[y.strip() for y in x.split(',')] for x in df['FORRT_clusters'].values]
-    df['tags'] = [[y.strip() for y in x.split(',')] for x in df['tags'].values]
+    # `tags` becomes a Hugo taxonomy, so a blank cell would otherwise yield
+    # [""] and collect every such resource into one archive; the sheet also
+    # carries "-" and "." as stand-ins for "no tags". Anything without a
+    # letter or digit is a placeholder, not a term, so drop it — the resource
+    # itself is kept, it just ends up untagged.
+    df['tags'] = [[y.strip() for y in x.split(',')
+                   if any(ch.isalnum() for ch in y)]
+                  for x in df['tags'].values]
     df['language'] = [[y.strip() for y in x.split(',')] for x in df['language'].values]
 
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-{{- $language_code := site.Language.Locale | default "en-us" -}}
+{{- /* Not always the site locale: glossary terms are written in five languages
+       and declare their own. See `functions/page_language.html`. */ -}}
+{{- $language_code := partial "functions/page_language.html" . -}}
 <html lang="{{$language_code}}" {{ if in hugo.Data.i18n.rtl.rtl $language_code }}dir="rtl"{{end}}>
 
 {{ partial "site_head" . }}

--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -8,6 +8,15 @@
 {{ partial "structured-data/glossary-term.html" . }}
 {{ partial "structured-data/educators-corner.html" . }}
 
+{{ partial "structured-data/breadcrumbs.html" . }}
+
+{{/* Thin `tags` archives: browsable and still passing link equity, but kept
+     out of search results. See `functions/is_thin_taxonomy.html`, which the
+     sitemap template consults too so the two cannot disagree. */}}
+{{ if partial "functions/is_thin_taxonomy.html" . }}
+  <meta name="robots" content="noindex, follow">
+{{ end }}
+
 {{/* Author profile pages: noindex empty template stubs, and emit Person
      structured data for the substantive ones. (Computed once.) */}}
 {{ if and (eq .Section "authors") .Params.name }}

--- a/layouts/partials/functions/glossary_translations.html
+++ b/layouts/partials/functions/glossary_translations.html
@@ -1,0 +1,33 @@
+{{/* Builds the glossary translation index: English term -> every language it
+     exists in.
+
+     The five glossaries are separate content directories rather than Hugo
+     language sites, so `.Translations` is empty for them and nothing links a
+     term to its counterparts. Each term carries `en_title` (written by
+     `content/glossary/_create_glossaries.py`) naming the concept it defines, so
+     grouping on that reconstructs the sets.
+
+     Call through `partialCached` with a fixed key — the index is the same for
+     every page and walking ~1,300 pages per page would be needlessly slow.
+
+     Inputs: any page context. Output: map of lowercased `en_title` to a slice
+     of `{tag, url}` dicts, one per language. */}}
+
+{{ $index := newScratch }}
+
+{{/* `site.Pages` rather than `site.RegularPages` so the five glossary landing
+     pages — which are section pages, and the most linked-to of the set — join
+     the clusters alongside the individual terms. Requiring `en_title` below
+     keeps everything else out. */}}
+{{ range where site.Pages "Type" "glossary" }}
+  {{/* Held in a variable because `with` below rebinds `.` to the title. */}}
+  {{ $term := . }}
+  {{ with .Params.en_title }}
+    {{ $index.Add (lower .) (slice (dict
+      "tag" (partial "functions/page_language.html" $term)
+      "url" $term.Permalink
+    )) }}
+  {{ end }}
+{{ end }}
+
+{{ return $index.Values }}

--- a/layouts/partials/functions/is_thin_taxonomy.html
+++ b/layouts/partials/functions/is_thin_taxonomy.html
@@ -1,0 +1,35 @@
+{{/* Reports whether a page is a low-value `tags` archive that should be kept
+     out of search results and out of the sitemap.
+
+     Tags are free text entered on curated resources, so the taxonomy has grown
+     to ~1,600 terms of which roughly three quarters apply to a single resource.
+     Those term pages restate one card and little else, which is thin,
+     near-duplicate content at a scale that dominates the sitemap.
+
+     Two kinds of page qualify:
+       - a term page (`/tag/<term>/`) with fewer than `tag_index_min_pages`
+         entries;
+       - the term index (`/tag/`) itself, which is a flat list of every term and
+         serves no search intent.
+
+     Only the `tags` taxonomy is affected. `categories`, `publication_types` and
+     `FORRT_clusters` are curated vocabularies and are left alone.
+
+     Inputs: page context. Output: bool. */}}
+
+{{ $min := site.Params.tag_index_min_pages | default 0 }}
+{{ $thin := false }}
+
+{{ if gt $min 0 }}
+  {{ $taxonomy := "" }}
+  {{ with .Data }}{{ $taxonomy = .Plural | default "" }}{{ end }}
+  {{ if eq $taxonomy "tags" }}
+    {{ if eq .Kind "term" }}
+      {{ $thin = lt (len .Pages) $min }}
+    {{ else if eq .Kind "taxonomy" }}
+      {{ $thin = true }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $thin }}

--- a/layouts/partials/functions/page_language.html
+++ b/layouts/partials/functions/page_language.html
@@ -1,0 +1,38 @@
+{{/* Resolves the BCP-47 language tag a page should declare.
+
+     The site is configured as single-language, so `site.Language.Locale` is
+     `en-US` everywhere — including the ~1,000 glossary terms written in German,
+     Arabic, Turkish and Chinese, which were being served as US English. Those
+     pages carry a `language` param naming their glossary, so it is used in
+     preference to the site locale.
+
+     The returned tag is also what `baseof.html` tests against
+     `data/i18n/rtl.toml` to decide text direction, so Arabic must resolve to a
+     bare `ar` for that lookup to match.
+
+     Inputs: page context. Output: language tag (string). */}}
+
+{{ $tags := dict
+  "english" "en-US"
+  "german"  "de"
+  "arabic"  "ar"
+  "turkish" "tr"
+  "chinese" "zh-Hans"
+}}
+
+{{/* Scoped to glossary terms on purpose. `curated_resources` also carry a
+     `language` param, but it records the language of the linked resource (and
+     holds a list, e.g. `["English"]`), not the language this page is written
+     in. */}}
+{{ $tag := site.Language.Locale | default "en-us" }}
+{{ if eq .Type "glossary" }}
+  {{ with .Params.language }}
+    {{ if reflect.IsSlice . }}
+      {{ $tag = index $tags (lower (index . 0)) | default $tag }}
+    {{ else }}
+      {{ $tag = index $tags (lower .) | default $tag }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $tag }}

--- a/layouts/partials/jsonld/business.html
+++ b/layouts/partials/jsonld/business.html
@@ -1,0 +1,62 @@
+{{/* Site override of the theme's `jsonld/business.html`.
+
+     Two fixes over the theme version:
+       - it built the `image` URL as `<media_dir>/<sharing_image>`, but
+         `sharing_image` is already a path under `static/`, so the tag pointed
+         at `/media/img/...`, which 404s. `site_head.html` resolves the same
+         param with a plain `absURL`; this now matches it.
+       - it emitted no `sameAs`, leaving search engines nothing to link this
+         site to FORRT's profiles elsewhere when resolving it as an entity.
+
+     Assembled as a dict and passed through `jsonify` so optional fields can be
+     added without hand-managing separators between them. */}}
+
+{{ $org := dict
+  "@context" "https://schema.org"
+  "@type" (site.Params.local_business_type | default site.Params.site_type)
+  "@id" site.BaseURL
+  "url" site.BaseURL
+  "name" (site.Params.org_name | default site.Title)
+  "logo" (partial "functions/get_logo_url" .)
+}}
+
+{{ with site.Params.short_title }}
+  {{ $org = merge $org (dict "alternateName" .) }}
+{{ end }}
+
+{{ with site.Params.description }}
+  {{ $org = merge $org (dict "description" .) }}
+{{ end }}
+
+{{ with site.Params.sharing_image }}
+  {{ $org = merge $org (dict "image" (. | absURL)) }}
+{{ end }}
+
+{{ with site.Params.social_profiles }}
+  {{ $org = merge $org (dict "sameAs" .) }}
+{{ end }}
+
+{{ if and (eq site.Params.site_type "LocalBusiness") site.Params.coordinates }}
+  {{ $org = merge $org (dict "geo" (dict
+    "@type" "GeoCoordinates"
+    "latitude" site.Params.coordinates.latitude
+    "longitude" site.Params.coordinates.longitude
+  )) }}
+{{ end }}
+
+{{ with site.Params.address }}
+  {{ $org = merge $org (dict "address" (dict
+    "@type" "PostalAddress"
+    "streetAddress" (.street | default "")
+    "addressLocality" (.city | default "")
+    "addressRegion" (.region | default "")
+    "postalCode" (.postcode | default "")
+    "addressCountry" (.country_code | default .country | default "")
+  )) }}
+{{ end }}
+
+{{ with site.Params.phone }}
+  {{ $org = merge $org (dict "telephone" .) }}
+{{ end }}
+
+<script type="application/ld+json">{{ $org | jsonify | safeJS }}</script>

--- a/layouts/partials/jsonld/main.html
+++ b/layouts/partials/jsonld/main.html
@@ -1,0 +1,79 @@
+{{/* Site override of the theme's `jsonld/main.html`.
+
+     The theme dispatches structured data for the home page and for `post`,
+     `publication`, `project` and `talk` singles, and emits nothing for list
+     pages. That left the section landings — `/summaries/`, `/publications/`,
+     `/resources/`, `/educators-corner/`, the glossaries — describing themselves
+     to search engines as nothing at all, despite being the pages most likely to
+     rank for a topic rather than a title.
+
+     This adds a `CollectionPage` for those, carrying an `ItemList` of what the
+     page actually lists. Everything the theme already handled is delegated
+     back to it unchanged. */}}
+
+{{ $page := .page }}
+{{ $summary := .summary }}
+{{ $site_type := site.Params.site_type | default "Person" }}
+
+{{- if $page.IsHome -}}
+
+  {{ partial "jsonld/website.html" $page }}
+
+  {{ if ne $site_type "Person" }}
+    {{ partial "jsonld/business.html" $page }}
+  {{ end }}
+
+{{- else if $page.IsPage -}}
+
+  {{ if (eq $page.Type "post") | or (eq $page.Type "publication") | or (eq $page.Type "project") }}
+    {{ partial "jsonld/article.html" (dict "page" $page "summary" $summary) }}
+  {{ end }}
+
+  {{ if eq $page.Type "talk" }}
+    {{ partial "jsonld/event.html" (dict "page" $page "summary" $summary) }}
+  {{ end }}
+
+{{- else if in (slice "section" "taxonomy" "term") $page.Kind -}}
+
+  {{/* Thin tag archives are `noindex`, so describing them only adds weight. */}}
+  {{ if not (partial "functions/is_thin_taxonomy.html" $page) }}
+
+    {{ $collection := dict
+      "@context" "https://schema.org"
+      "@type" "CollectionPage"
+      "@id" (printf "%s#collection" $page.Permalink)
+      "url" $page.Permalink
+      "name" $page.Title
+      "isPartOf" (dict "@type" "WebSite" "@id" site.BaseURL "name" site.Title)
+      "inLanguage" (partial "functions/page_language.html" $page)
+    }}
+
+    {{ with $summary }}
+      {{ $collection = merge $collection (dict "description" (. | plainify | truncate 300 "…")) }}
+    {{ end }}
+
+    {{/* Capped: these lists run to hundreds of entries, and the point is to
+         describe what the page covers, not to mirror it. */}}
+    {{ $elements := slice }}
+    {{ range $i, $item := first 25 $page.Pages }}
+      {{ $elements = $elements | append (dict
+        "@type" "ListItem"
+        "position" (add $i 1)
+        "url" $item.Permalink
+        "name" $item.LinkTitle
+      ) }}
+    {{ end }}
+
+    {{ if $elements }}
+      {{ $collection = merge $collection (dict "mainEntity" (dict
+        "@type" "ItemList"
+        "numberOfItems" (len $page.Pages)
+        "itemListElement" $elements
+      )) }}
+    {{ end }}
+
+<script type="application/ld+json">{{ $collection | jsonify | safeJS }}</script>
+
+  {{ end }}
+
+{{- end }}

--- a/layouts/partials/li_card.html
+++ b/layouts/partials/li_card.html
@@ -47,7 +47,10 @@
   {{ with $resource }}
   {{ $image := .Fill (printf "918x517 q90 %s" $anchor) }}
   <a href="{{ $item.RelPermalink }}">
-      <img src="{{ $image.RelPermalink }}" class="article-banner" alt="{{ $item.Params.image.alttext }}">
+      {{/* Fall back to the title: `image.alttext` is set on almost no posts, so
+           these banners were shipping an empty `alt` despite being meaningful
+           content rather than decoration. */}}
+      <img src="{{ $image.RelPermalink }}" class="article-banner" alt="{{ $item.Params.image.alttext | default $item.Title }}">
   </a>
   {{end}}
 

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -48,10 +48,20 @@
     {{ $desc = .Params.definition }}
   {{ else if .IsPage }}
     {{ $desc = .Summary }}
-  {{ else if site.Params.description }}
-    {{ $desc = site.Params.description }}
-  {{ else }}
-    {{ $desc = $superuser_role }}
+  {{ end }}
+  {{/* `summary`, `abstract` and `definition` are raw Markdown in front matter,
+       so `**bold**`, `[text](url)` and escaped brackets were reaching search
+       results verbatim (262 glossary definitions carry bold markers alone).
+       Render first, then flatten: `.Summary` is already HTML and passes through
+       unchanged, and `plainify` strips the markup either way. */}}
+  {{ $desc = trim (.RenderString $desc | plainify) " \n\r\t" }}
+  {{/* Widget-composed pages (`headless = true`) render no body of their own, so
+       `.Summary` is empty for them even though `.IsPage` is true. The branch
+       above therefore matches and sets an empty description, which is why the
+       site-wide fallback has to test the *result* for content rather than sit
+       at the end of the chain as another `else if`. */}}
+  {{ if not $desc }}
+    {{ $desc = site.Params.description | default $superuser_role }}
   {{ end }}
   <meta name="description" content='{{ printf "%.254s" $desc }}'>
   {{/* Shorter description for social previews (avoids mid-word truncation). */}}
@@ -64,10 +74,37 @@
     {{ $og_desc = printf "%.200s" $desc }}
   {{ end }}
 
+  {{ $page_lang := partial "functions/page_language.html" . }}
+
   {{ range .Translations }}
   <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
   {{ end }}
-  <link rel="alternate" hreflang="{{ site.Language.Locale | default "en-us" }}" href="{{ .Permalink }}">
+
+  {{/* Glossary terms live in five parallel content directories rather than Hugo
+       language sites, so `.Translations` is empty for them. Rebuild the set by
+       grouping on `en_title` and emit the whole cluster on every member —
+       hreflang is only honoured when the annotations are reciprocal and each
+       page also points at itself. */}}
+  {{ $cluster := slice }}
+  {{ if eq .Type "glossary" }}
+    {{ with .Params.en_title }}
+      {{ $translations := partialCached "functions/glossary_translations.html" $ "glossary-translations" }}
+      {{ $cluster = index $translations (lower .) | default slice }}
+    {{ end }}
+  {{ end }}
+
+  {{ if $cluster }}
+    {{ range sort $cluster "tag" }}
+  <link rel="alternate" hreflang="{{ .tag }}" href="{{ .url }}">
+    {{- end }}
+    {{/* English is the source glossary, so it is the sensible landing point for
+         a searcher whose language we do not publish. */}}
+    {{ range where $cluster "tag" "en-US" }}
+  <link rel="alternate" hreflang="x-default" href="{{ .url }}">
+    {{- end }}
+  {{ else }}
+  <link rel="alternate" hreflang="{{ $page_lang }}" href="{{ .Permalink }}">
+  {{ end }}
 
   {{ partial "functions/parse_theme" . }}
   {{ $css := hugo.Data.assets.css }}
@@ -81,6 +118,15 @@
   {{ $mathjax_config := resources.Get "js/mathjax-config.js" }}
   <script src="{{ $mathjax_config.RelPermalink }}"></script>
   {{ end }}
+
+  {{/* Every render-blocking stylesheet below the first comes from a third-party
+       origin, so the browser cannot start fetching any of them until it has
+       paid for a DNS lookup, TCP connection and TLS handshake it does not yet
+       know it needs. Warming the connections costs nothing and moves that work
+       off the critical path. */}}
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
   {{/* Attempt to load local vendor CSS, otherwise load from CDN. */}}
   {{ $scr.Set "vendor_css_filename" "main.min.css" }}
@@ -120,7 +166,13 @@
       {{ end }}
     {{ end }}
 
-    {{ if or (eq site.Params.map.engine 2) (eq site.Params.map.engine 3) }}
+    {{/* Leaflet was render-blocking on all ~5,400 pages because `map.engine` is
+         a site-wide setting. The only maps on the site come from the `ga_map`
+         shortcodes; the Contact widget's map needs `coordinates`, which is not
+         set, and the community map and contributor network render inside
+         iframes that load their own copies. So load it per page instead. */}}
+    {{ $needs_map := or (.HasShortcode "ga_map") (.HasShortcode "ga_map_yearly") (.Params.needs_map | default false) }}
+    {{ if and $needs_map (or (eq site.Params.map.engine 2) (eq site.Params.map.engine 3)) }}
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.leaflet.url $css.leaflet.version) $css.leaflet.sri | safeHTML }}
     {{ end }}
 
@@ -246,7 +298,7 @@
   {{ else if .IsHome }}
     {{ $og_title = site.Title }}
   {{ else }}
-    {{ $og_title = printf "%s | %s" .Title site.Title }}
+    {{ $og_title = printf "%s | %s" .Title (site.Params.short_title | default site.Title) }}
   {{ end }}
   <meta property="og:title" content="{{ $og_title }}">
   <meta property="og:description" content='{{ $og_desc }}'>
@@ -262,7 +314,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="{{ $og_image }}">
   {{- end -}}
-  <meta property="og:locale" content="{{ site.Language.Locale | default "en-us" }}">
+  <meta property="og:locale" content="{{ $page_lang }}">
   {{ if .IsPage }}
     {{ if not .PublishDate.IsZero }}
       <meta property="article:published_time" content="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">
@@ -280,6 +332,10 @@
 
   {{ partial "custom_head" . }}
 
-  <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ site.Title }}</title>
+  {{/* Search engines truncate titles at roughly 60 characters. Suffixing every
+       page with the full site title spent 61 of those on text that was never
+       displayed, so pages carry the short name and only the home page spells
+       the organisation out in full. */}}
+  <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} | {{ site.Params.short_title | default site.Title }}{{ end }}</title>
 
 </head>

--- a/layouts/partials/structured-data/breadcrumbs.html
+++ b/layouts/partials/structured-data/breadcrumbs.html
@@ -1,0 +1,63 @@
+{{/* BreadcrumbList for every page deep enough to have a trail.
+
+     Breadcrumbs replace the raw URL line in a search result with a readable
+     hierarchy, which matters on a site this deep — most content sits two or
+     three levels down (`/about/mission/`, `/glossary/german/<term>/`).
+
+     Skipped for:
+       - the home page, which is the root of every trail;
+       - `clusters`, which builds a richer trail of its own in
+         `clusters/cluster_seo_jsonld.html` — two BreadcrumbLists on one page
+         would compete;
+       - thin tag archives, which are `noindex` and so will never render a
+         result to enhance.
+
+     The skips are one wrapping conditional rather than early `return`s: a Hugo
+     partial either returns a value or writes output, and mixing the two makes
+     the `return` silently fail to stop rendering.
+
+     `jsonify` escapes `<`, `>` and `&`, so titles cannot break out of the
+     script element.
+
+     Inputs: page context. */}}
+
+{{ $skip := or
+  .IsHome
+  (eq .Type "clusters")
+  (partial "functions/is_thin_taxonomy.html" .)
+}}
+
+{{ if not $skip }}
+  {{ $trail := slice }}
+
+  {{ range .Ancestors.Reverse }}
+    {{ $ancestor := . }}
+    {{ $name := cond .IsHome (site.Params.short_title | default site.Title) (.LinkTitle | default .Title) }}
+    {{ if $name }}
+      {{ $trail = $trail | append (dict
+        "@type" "ListItem"
+        "position" (add (len $trail) 1)
+        "name" $name
+        "item" $ancestor.Permalink
+      ) }}
+    {{ end }}
+  {{ end }}
+
+  {{ with .LinkTitle | default .Title }}
+    {{ $trail = $trail | append (dict
+      "@type" "ListItem"
+      "position" (add (len $trail) 1)
+      "name" .
+      "item" $.Permalink
+    ) }}
+  {{ end }}
+
+  {{/* A single entry is just the page itself — no hierarchy worth describing. */}}
+  {{ if gt (len $trail) 1 }}
+<script type="application/ld+json">{{ (dict
+  "@context" "https://schema.org"
+  "@type" "BreadcrumbList"
+  "itemListElement" $trail
+) | jsonify | safeJS }}</script>
+  {{ end }}
+{{ end }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,34 @@
+{{/* Override of Hugo's built-in sitemap template.
+
+     Identical to the built-in output except that pages judged low-value by
+     `functions/is_thin_taxonomy.html` are skipped. Those same pages are served
+     with `noindex, follow` (see `partials/custom_head.html`); listing a
+     noindexed URL in the sitemap sends search engines two contradictory
+     signals, so both rules read the same predicate.
+
+     Kept deliberately close to the built-in template so it stays easy to diff
+     against upstream when Hugo changes. */ -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- range .Pages -}}
+    {{- if not (partial "functions/is_thin_taxonomy.html" .) -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>
+    {{- end }}
+    {{- with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>
+    {{- end }}
+    {{- if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>
+    {{- end }}
+    {{- if .IsTranslated }}
+      {{- range .AllTranslations }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.LanguageCode }}" href="{{ .Permalink }}" />
+      {{- end }}
+    {{- end }}
+  </url>
+    {{- end -}}
+  {{- end }}
+</urlset>


### PR DESCRIPTION
Splits #850 into a reviewable template change (this PR) and the generated content it implies (#853). Original work by @Keegan-Vaz; this PR carries the same templates plus the generator fixes that make them stick.

## Why the split

#850 was 1,450 files. Twelve of them were the actual change; the other 1,438 were generated output — and neither set of edits survived. `content/curated_resources/` is deleted and rewritten from a Google Sheet by the daily `data-processing` workflow, so the 136 tag cleanups would have reverted within 24 hours. `content/glossary/` is deleted and rewritten by `_create_glossaries.py`, which was never taught to emit `en_title`, so the next regeneration would have silently dropped hreflang from all 1,300 glossary pages.

Both are now fixed at the source.

## What's here

**Templates and config** — metadata fallbacks, short titles, Markdown-free descriptions, Organization JSON-LD, thin-tag `noindex` + sitemap exclusion behind one shared predicate, per-page language resolution, glossary hreflang, BreadcrumbList, CollectionPage/ItemList, preconnect hints, per-page Leaflet, banner `alt`. See the commit message for the detail.

**`content/resources/resource.py`** — drops placeholder tag entries (`""`, `"-"`, `"."`) as the resources are generated. Verified against the live sheet: 0 placeholder entries remain, 135 rows get `tags: []`, 1,686 real terms and all other columns untouched.

**`content/glossary/_create_glossaries.py`** — emits `en_title` from the `EN_title` column it already reads.

## Fixes found while reviewing #850

- **The sitemap override did not parse as XML.** The `<?xml …?>` declaration was written as literal template text; Hugo escapes it to `&lt;?xml`, and `xmllint` rejects the whole document. That made the headline indexation fix strictly worse than the sitemap it replaced. Now emitted through `safeHTML`.
- **`layouts/404.html` was reverted** to its pre-#851 state. Restored.

## Testing

Full `hugo` build, no warnings. Sitemap validates (`xmllint`), 3,174 URLs, down from 4,631. 0 empty meta descriptions, down from 58. BreadcrumbList on 3,784 pages with no double-emission on `/clusters/`. Arabic glossary pages render `<html lang="ar" dir="rtl">`. `/tag/-/` is gone.

## Merge order

Either order works — hreflang no-ops until `en_title` exists in the content, so nothing breaks. #853 is stacked on this branch.

## Not addressed

`og:image` is still a 4000x2250 WebP (needs a generated 1200x630 raster); `og:locale` emits bare language tags where Open Graph wants `language_TERRITORY`; highlight.js still loads on every page. The `tag_index_min_pages = 5` floor de-indexes ~1,500 tag archives — that's a content-strategy call worth a maintainer's explicit sign-off rather than something to inherit from a bug-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)