### PR TITLE
Fix link-check crash from html module shadowing

### DIFF
--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -348,13 +348,13 @@ jobs:
 
           # doi -> set of source pages
           doi_pages = defaultdict(set)
-          for html in SITE_ROOT.rglob("*.html"):
+          for page_file in SITE_ROOT.rglob("*.html"):
               try:
-                  text = html.read_text(errors="ignore")
+                  text = page_file.read_text(errors="ignore")
               except Exception:
                   continue
               # Strip the artifact-name dir (/tmp/site/<artifact>/<path>) -> /<path>
-              rel_parts = html.relative_to(SITE_ROOT).parts[1:]
+              rel_parts = page_file.relative_to(SITE_ROOT).parts[1:]
               page = "/" + "/".join(rel_parts)
               page = re.sub(r"/index\.html$", "/", page)
               for m in DOI_RE.finditer(text):


### PR DESCRIPTION
The DOI validation step failed with `AttributeError: 'PosixPath' object has no attribute 'unescape'` ([run 31986717339](https://github.com/forrtproject/forrtproject.github.io/actions/runs/31986717339/job/95262883594)).

The page loop used `html` as its variable name, rebinding the imported `html` module to a `Path` before `html.unescape()` is called. Renamed the loop variable to `page_file`.

Verified locally by extracting the step's script and running it over a fake site: real DOIs (incl. a SICI DOI with parens, an HTML-escaped bioRxiv DOI with a version suffix) pass, a fabricated DOI is reported as broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)