### PR TITLE
Add feedback/suggestion forms to Glossary and Adopting Principled Education pages

### DIFF
--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -19,7 +19,7 @@
  */
 
 var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4';
-var SHEET_NAME = 'feedback';
+var SHEET_NAME = 'Forrt-feedbacks';
 var GLOSSARY_SHEET_NAME = 'glossary_feedback';
 var ADOPTING_SHEET_NAME = 'adopting_feedback';
 
@@ -116,7 +116,7 @@ function _getOrCreateSheet(name, headers) {
 
 // Health check for GET requests.
 function doGet() {
-  return _json({ ok: true, service: 'just-os-feedback' });
+  return _json({ ok: true, service: 'FORRT Feedback Forms' });
 }
 
 function _json(obj) {

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -18,10 +18,10 @@
  * Sheets are created automatically (with headers) on first submission.
  */
 
-var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4';
-var SHEET_NAME = 'feedback';
-var GLOSSARY_SHEET_NAME = 'glossary_feedback';
-var ADOPTING_SHEET_NAME = 'adopting_feedback';
+var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4'; // Forrt-feedbacks sheet (contains all three feedback sheets)
+var SHEET_NAME = 'feedback'; // just-os feedback
+var GLOSSARY_SHEET_NAME = 'glossary_feedback'; // glossary feedback
+var ADOPTING_SHEET_NAME = 'adopting_feedback'; // adopting feedback
 
 function doPost(e) {
   try {

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -19,7 +19,7 @@
  */
 
 var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4';
-var SHEET_NAME = 'Forrt-feedbacks';
+var SHEET_NAME = 'feedback';
 var GLOSSARY_SHEET_NAME = 'glossary_feedback';
 var ADOPTING_SHEET_NAME = 'adopting_feedback';
 

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -9,14 +9,19 @@
  *
  *   - Glossary entry feedback/suggestion form (`type: "glossary_feedback"`):
  *     sheet "glossary_feedback" — { term, url, language, feedback_type,
- *     message, email, ts }. Sheet is created automatically (with headers)
- *     on first submission.
+ *     message, email, ts }.
  *
+ *   - Adopting Principled Education feedback form (`type: "adopting_feedback"`):
+ *     sheet "adopting_feedback" — { tips_used, what_worked, demographics,
+ *     demographics_other, additional_comments, url, ts }.
+ *
+ * Sheets are created automatically (with headers) on first submission.
  */
 
 var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4';
 var SHEET_NAME = 'feedback';
 var GLOSSARY_SHEET_NAME = 'glossary_feedback';
+var ADOPTING_SHEET_NAME = 'adopting_feedback';
 
 function doPost(e) {
   try {
@@ -25,8 +30,14 @@ function doPost(e) {
     if (data.type === 'glossary_feedback') {
       return _handleGlossaryFeedback(data);
     }
+    if (data.type === 'adopting_feedback') {
+      return _handleAdoptingFeedback(data);
+    }
     return _handleChatFeedback(data);
   } catch (err) {
+    // Clients POST with `mode: 'no-cors'` and never read this response, so an
+    // error here is otherwise invisible; returning it (rather than throwing)
+    // at least leaves a trace in the Apps Script execution log.
     return _json({ ok: false, error: String(err) });
   }
 }
@@ -65,6 +76,27 @@ function _handleGlossaryFeedback(data) {
     data.feedback_type || '',
     data.message || '',
     data.email || '',
+  ]);
+
+  return _json({ ok: true });
+}
+
+function _handleAdoptingFeedback(data) {
+  var sheet = _getOrCreateSheet(ADOPTING_SHEET_NAME, [
+    'received_at', 'ts', 'tips_used', 'what_worked', 'demographics', 'demographics_other', 'additional_comments', 'url',
+  ]);
+
+  sheet.appendRow([
+    new Date(),                        // received_at (server time)
+    data.ts || '',                     // ts (client epoch ms)
+    data.tips_used || '',
+    data.what_worked || '',
+    // Demographics arrive as an array of checked values; flattened to a
+    // single string since a spreadsheet cell can't hold a list.
+    (data.demographics || []).join(', '),
+    data.demographics_other || '',
+    data.additional_comments || '',
+    data.url || '',
   ]);
 
   return _json({ ok: true });

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -1,38 +1,85 @@
 /**
- * JUST-OS chat feedback receiver.
- * Appends one row per feedback event to the "feedback" sheet.
+ * FORRT feedback receiver (single Apps Script web app, multiple sources).
+ * Appends one row per feedback event to a sheet in SHEET_ID, picking the
+ * sheet/schema from `data.type`:
  *
- * The client POSTs JSON as text/plain (a CORS "simple request") so no
- * preflight is needed. Payload:
- *   { turn_id, rho_exp, signals:{copy,followup,fast_exit}, comment, query, response, ts }
+ *   - JUST-OS chat feedback (no `type`, or `type: "chat"`):
+ *     sheet "feedback" — { turn_id, rho_exp, signals:{copy,followup,fast_exit},
+ *     comment, query, response, ts }
+ *
+ *   - Glossary entry feedback/suggestion form (`type: "glossary_feedback"`):
+ *     sheet "glossary_feedback" — { term, url, language, feedback_type,
+ *     message, email, ts }. Sheet is created automatically (with headers)
+ *     on first submission.
+ *
  */
 
-var SHEET_ID = '1unzrmBhMmvHEohIU_B2V9ObcftIluveQA6ZPe6THZpc';
+var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4';
 var SHEET_NAME = 'feedback';
+var GLOSSARY_SHEET_NAME = 'glossary_feedback';
 
 function doPost(e) {
   try {
     var data = JSON.parse((e && e.postData && e.postData.contents) || '{}');
-    var signals = data.signals || {};
-    var sheet = SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
 
-    sheet.appendRow([
-      new Date(),                 // received_at (server time)
-      data.ts || '',              // ts (client epoch ms)
-      data.turn_id || '',
-      data.rho_exp,               // +1 | -1 | 0
-      signals.copy ? 1 : '',
-      signals.followup ? 1 : '',
-      signals.fast_exit ? 1 : '',
-      data.comment || '',
-      data.query || '',
-      data.response || '',
-    ]);
-
-    return _json({ ok: true });
+    if (data.type === 'glossary_feedback') {
+      return _handleGlossaryFeedback(data);
+    }
+    return _handleChatFeedback(data);
   } catch (err) {
     return _json({ ok: false, error: String(err) });
   }
+}
+
+function _handleChatFeedback(data) {
+  var signals = data.signals || {};
+  var sheet = SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+
+  sheet.appendRow([
+    new Date(),                 // received_at (server time)
+    data.ts || '',              // ts (client epoch ms)
+    data.turn_id || '',
+    data.rho_exp,               // +1 | -1 | 0
+    signals.copy ? 1 : '',
+    signals.followup ? 1 : '',
+    signals.fast_exit ? 1 : '',
+    data.comment || '',
+    data.query || '',
+    data.response || '',
+  ]);
+
+  return _json({ ok: true });
+}
+
+function _handleGlossaryFeedback(data) {
+  var sheet = _getOrCreateSheet(GLOSSARY_SHEET_NAME, [
+    'received_at', 'ts', 'term', 'url', 'language', 'feedback_type', 'message', 'email',
+  ]);
+
+  sheet.appendRow([
+    new Date(),                 // received_at (server time)
+    data.ts || '',              // ts (client epoch ms)
+    data.term || '',
+    data.url || '',
+    data.language || '',
+    data.feedback_type || '',
+    data.message || '',
+    data.email || '',
+  ]);
+
+  return _json({ ok: true });
+}
+
+// Returns the named sheet in SHEET_ID, creating it with a header row if it
+// doesn't exist yet.
+function _getOrCreateSheet(name, headers) {
+  var ss = SpreadsheetApp.openById(SHEET_ID);
+  var sheet = ss.getSheetByName(name);
+  if (!sheet) {
+    sheet = ss.insertSheet(name);
+    sheet.appendRow(headers);
+  }
+  return sheet;
 }
 
 // Health check for GET requests.

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -18,7 +18,7 @@
  * Sheets are created automatically (with headers) on first submission.
  */
 
-var SHEET_ID = '1YTDMUgBzHTy558M5u3ClrnwMnbKF_nxWn0ufLnqBJY4'; // Forrt-feedbacks sheet (contains all three feedback sheets)
+var SHEET_ID = '1unzrmBhMmvHEohIU_B2V9ObcftIluveQA6ZPe6THZpc';
 var SHEET_NAME = 'feedback'; // just-os feedback
 var GLOSSARY_SHEET_NAME = 'glossary_feedback'; // glossary feedback
 var ADOPTING_SHEET_NAME = 'adopting_feedback'; // adopting feedback

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -33,7 +33,11 @@ function doPost(e) {
     if (data.type === 'adopting_feedback') {
       return _handleAdoptingFeedback(data);
     }
-    return _handleChatFeedback(data);
+    // No `type` = chat payloads from cached copies of the previous just-os-chat.js.
+    if (data.type === 'chat' || !data.type) {
+      return _handleChatFeedback(data);
+    }
+    return _json({ ok: false, error: 'unknown type: ' + data.type });
   } catch (err) {
     // Clients POST with `mode: 'no-cors'` and never read this response, so an
     // error here is otherwise invisible; returning it (rather than throwing)

--- a/.feedback-appscript/Code.js
+++ b/.feedback-appscript/Code.js
@@ -48,7 +48,9 @@ function doPost(e) {
 
 function _handleChatFeedback(data) {
   var signals = data.signals || {};
-  var sheet = SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+  var sheet = _getOrCreateSheet(SHEET_NAME, [
+    'received_at', 'ts', 'turn_id', 'rho_exp', 'copy', 'followup', 'fast_exit', 'comment', 'query', 'response',
+  ]);
 
   sheet.appendRow([
     new Date(),                 // received_at (server time)

--- a/content/adopting/adopting.md
+++ b/content/adopting/adopting.md
@@ -362,7 +362,8 @@ A great way to adopt the values of principled education is to advocate in your o
 
 Have you used any of these tips? What do you think worked well or what did you have to change? What demographic of students did you use this for (e.g. Bachelor, Masters, PhD)? 
 
-We welcome contributions from educators, researchers, and practitioners who would like to help expand and enrich these resources. Have your say through this Google Form. 
+We welcome contributions from educators, researchers, and practitioners who would like to help expand and enrich these resources. Have your say through the form below.
+
 
 **Share back**
 
@@ -374,4 +375,6 @@ You can also submit a short contribution to FORRT’s curated database or direct
 
 * a case study
 
-Submissions can be made via our short [Google Form](). Please note that contributors can get credit. We are committed to transparent and meaningful attribution. Contributors are credited using our formal crediting mechanism (Tenzing / CRediT taxonomy). When submitting via the Google Form, you will be invited to add your details so that you can be properly credited for your contribution. We value community knowledge and aim to recognise all contributions appropriately
+Submissions can be made via our short Google Form below. Please note that contributors can get credit. We are committed to transparent and meaningful attribution. Contributors are credited using our formal crediting mechanism (Tenzing / CRediT taxonomy). When submitting via the Google Form, you will be invited to add your details so that you can be properly credited for your contribution. We value community knowledge and aim to recognise all contributions appropriately
+
+{{< adopting_feedback_form >}}

--- a/content/adopting/adopting.md
+++ b/content/adopting/adopting.md
@@ -375,6 +375,6 @@ You can also submit a short contribution to FORRT’s curated database or direct
 
 * a case study
 
-Submissions can be made via our short Google Form below. Please note that contributors can get credit. We are committed to transparent and meaningful attribution. Contributors are credited using our formal crediting mechanism (Tenzing / CRediT taxonomy). When submitting via the Google Form, you will be invited to add your details so that you can be properly credited for your contribution. We value community knowledge and aim to recognise all contributions appropriately
+Submissions can be made via our short  Form below. Please note that contributors can get credit. We are committed to transparent and meaningful attribution. Contributors are credited using our formal crediting mechanism (Tenzing / CRediT taxonomy). When submitting via the Form, you will be invited to add your details so that you can be properly credited for your contribution. We value community knowledge and aim to recognise all contributions appropriately
 
 {{< adopting_feedback_form >}}

--- a/content/adopting/adopting.md
+++ b/content/adopting/adopting.md
@@ -375,6 +375,6 @@ You can also submit a short contribution to FORRT’s curated database or direct
 
 * a case study
 
-Submissions can be made via our short  Form below. Please note that contributors can get credit. We are committed to transparent and meaningful attribution. Contributors are credited using our formal crediting mechanism (Tenzing / CRediT taxonomy). When submitting via the Form, you will be invited to add your details so that you can be properly credited for your contribution. We value community knowledge and aim to recognise all contributions appropriately
+Submissions can be made via the form below. Please note that contributors can get credit. We are committed to transparent and meaningful attribution. Contributors are credited using our formal crediting mechanism (Tenzing / CRediT taxonomy). When submitting via the form, you will be invited to add your details so that you can be properly credited for your contribution. We value community knowledge and aim to recognise all contributions appropriately.
 
 {{< adopting_feedback_form >}}

--- a/layouts/glossary/single.html
+++ b/layouts/glossary/single.html
@@ -336,6 +336,8 @@
             {{ end }}
             {{ end }}
 
+            {{ partial "glossary_feedback_form" . }}
+
             {{ if ne .Params.docs_section_pager false }}
             {{ if site.Params.docs_section_pager }}
             <div class="article-widget">

--- a/layouts/partials/glossary_feedback_form.html
+++ b/layouts/partials/glossary_feedback_form.html
@@ -146,6 +146,8 @@
     margin: 2.5rem 0 1.5rem;
     padding: 1.5rem 1.75rem;
     border: 1px solid rgba(0, 0, 0, 0.08);
+    /* Logical property (not border-left) so the accent stripe flips to the
+       visual right automatically on the Arabic (dir="rtl") pages. */
     border-inline-start: 4px solid #007bff;
     border-radius: 8px;
     background: rgba(0, 123, 255, 0.03);
@@ -250,6 +252,9 @@
   }
 </style>
 
+{{/* `| safeJS` is required here: without it, Hugo's contextual autoescaping
+     re-escapes the already-quoted jsonify output, doubling the quotes and
+     breaking the object literal below. */}}
 <script>
   window.GLOSSARY_FEEDBACK_I18N = {
     sending: {{ index $t "sending" | jsonify | safeJS }},

--- a/layouts/partials/glossary_feedback_form.html
+++ b/layouts/partials/glossary_feedback_form.html
@@ -1,0 +1,260 @@
+{{/* Feedback/suggestion form for individual glossary term pages.
+     Submits to the same Google Apps Script web app used by the JUST-OS chat
+     feedback widget (see .feedback-appscript/Code.js), which appends each
+     submission as a row to a "glossary_feedback" sheet — no backend to
+     maintain. See static/js/glossary-feedback.js for the client logic. */}}
+
+{{ $lang := .Params.language | default "english" }}
+{{ $dictionary := dict
+    "english" (dict
+        "heading" "Suggest an improvement"
+        "intro" "Spotted an error, a broken link, or think this entry is missing something? Let us know — this goes directly to the glossary team."
+        "type_label" "Type of feedback"
+        "type_placeholder" "Select a type…"
+        "type_correction" "Correction (error, typo, broken link)"
+        "type_suggestion" "Suggestion (missing term, related term, reference)"
+        "type_other" "Other"
+        "message_label" "Your feedback"
+        "message_placeholder" "Describe the issue or suggestion..."
+        "email_label" "Email (optional, if you'd like a reply)"
+        "submit" "Submit feedback"
+        "sending" "Sending…"
+        "thanks" "Thank you — your feedback has been recorded."
+        "error" "Something went wrong. Please try again later."
+    )
+    "german" (dict
+        "heading" "Verbesserungsvorschlag"
+        "intro" "Einen Fehler oder einen defekten Link entdeckt, oder fehlt diesem Eintrag etwas? Lassen Sie es uns wissen — das geht direkt an das Glossar-Team."
+        "type_label" "Art des Feedbacks"
+        "type_placeholder" "Art auswählen…"
+        "type_correction" "Korrektur (Fehler, Tippfehler, defekter Link)"
+        "type_suggestion" "Vorschlag (fehlender Begriff, verwandter Begriff, Referenz)"
+        "type_other" "Sonstiges"
+        "message_label" "Ihr Feedback"
+        "message_placeholder" "Beschreiben Sie das Problem oder den Vorschlag..."
+        "email_label" "E-Mail (optional, falls Sie eine Antwort wünschen)"
+        "submit" "Feedback senden"
+        "sending" "Wird gesendet…"
+        "thanks" "Vielen Dank — Ihr Feedback wurde gespeichert."
+        "error" "Etwas ist schiefgelaufen. Bitte versuchen Sie es später erneut."
+    )
+    "arabic" (dict
+        "heading" "اقترح تحسينًا"
+        "intro" "هل لاحظت خطأً أو رابطًا معطلاً، أو تعتقد أن هذا المدخل ينقصه شيء؟ أخبرنا — ستصل ملاحظتك مباشرة إلى فريق المسرد."
+        "type_label" "نوع الملاحظة"
+        "type_placeholder" "اختر نوعًا…"
+        "type_correction" "تصحيح (خطأ، خطأ إملائي، رابط معطل)"
+        "type_suggestion" "اقتراح (مصطلح مفقود، مصطلح ذو صلة، مرجع)"
+        "type_other" "أخرى"
+        "message_label" "ملاحظتك"
+        "message_placeholder" "صف المشكلة أو الاقتراح..."
+        "email_label" "البريد الإلكتروني (اختياري، إذا رغبت في الحصول على رد)"
+        "submit" "إرسال الملاحظة"
+        "sending" "جارٍ الإرسال…"
+        "thanks" "شكرًا لك — تم تسجيل ملاحظتك."
+        "error" "حدث خطأ ما. يرجى المحاولة مرة أخرى لاحقًا."
+    )
+    "turkish" (dict
+        "heading" "Bir iyileştirme önerin"
+        "intro" "Bir hata, bozuk bir bağlantı fark ettiniz mi ya da bu maddede eksik bir şey mi var? Bize bildirin — geri bildiriminiz doğrudan sözlük ekibine ulaşır."
+        "type_label" "Geri bildirim türü"
+        "type_placeholder" "Bir tür seçin…"
+        "type_correction" "Düzeltme (hata, yazım hatası, bozuk bağlantı)"
+        "type_suggestion" "Öneri (eksik terim, ilgili terim, kaynak)"
+        "type_other" "Diğer"
+        "message_label" "Geri bildiriminiz"
+        "message_placeholder" "Sorunu veya öneriyi açıklayın..."
+        "email_label" "E-posta (isteğe bağlı, yanıt almak isterseniz)"
+        "submit" "Geri bildirimi gönder"
+        "sending" "Gönderiliyor…"
+        "thanks" "Teşekkürler — geri bildiriminiz kaydedildi."
+        "error" "Bir şeyler ters gitti. Lütfen daha sonra tekrar deneyin."
+    )
+    "chinese" (dict
+        "heading" "提出改进建议"
+        "intro" "发现了错误、失效链接，或者认为此词条遗漏了什么？请告诉我们——您的反馈将直接发送给术语表团队。"
+        "type_label" "反馈类型"
+        "type_placeholder" "请选择反馈类型…"
+        "type_correction" "更正（错误、拼写错误、失效链接）"
+        "type_suggestion" "建议（缺失术语、相关术语、参考文献）"
+        "type_other" "其他"
+        "message_label" "您的反馈"
+        "message_placeholder" "请描述问题或建议..."
+        "email_label" "电子邮件（可选，如果您希望收到回复）"
+        "submit" "提交反馈"
+        "sending" "发送中…"
+        "thanks" "谢谢——您的反馈已记录。"
+        "error" "出现问题，请稍后重试。"
+    )
+}}
+{{ $t := index $dictionary $lang }}
+
+<section class="glossary-feedback"{{ if eq $lang "arabic" }} dir="rtl"{{ end }}>
+  <div class="glossary-feedback-header">
+    <span class="glossary-feedback-icon" aria-hidden="true">&#9998;</span>
+    <div>
+      <h3 class="glossary-feedback-heading">{{ index $t "heading" }}</h3>
+      <p class="glossary-feedback-intro">{{ index $t "intro" }}</p>
+    </div>
+  </div>
+
+  <form id="glossary-feedback-form"
+        class="glossary-feedback-form"
+        data-term="{{ .Title }}"
+        data-url="{{ .Permalink }}"
+        data-language="{{ $lang }}">
+
+    <div class="glossary-feedback-row">
+      <div class="form-group glossary-feedback-type">
+        <label for="glossary-feedback-type">{{ index $t "type_label" }}</label>
+        <select id="glossary-feedback-type" name="feedback_type" class="form-control" required>
+          <option value="" disabled selected>{{ index $t "type_placeholder" }}</option>
+          <option value="correction">{{ index $t "type_correction" }}</option>
+          <option value="suggestion">{{ index $t "type_suggestion" }}</option>
+          <option value="other">{{ index $t "type_other" }}</option>
+        </select>
+      </div>
+
+      <div class="form-group glossary-feedback-email">
+        <label for="glossary-feedback-email">{{ index $t "email_label" }}</label>
+        <input type="email" id="glossary-feedback-email" name="email" class="form-control">
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="glossary-feedback-message">{{ index $t "message_label" }}</label>
+      <textarea id="glossary-feedback-message" name="message" class="form-control" rows="3"
+                required placeholder="{{ index $t "message_placeholder" }}"></textarea>
+    </div>
+
+    {{/* Honeypot: hidden from sighted users and skipped by screen readers
+         via aria-hidden; most bots fill in every field regardless. */}}
+    <div class="glossary-feedback-hp" aria-hidden="true">
+      <label for="glossary-feedback-website">Website</label>
+      <input type="text" id="glossary-feedback-website" name="website" tabindex="-1" autocomplete="off">
+    </div>
+
+    <div class="glossary-feedback-actions">
+      <button type="submit" class="btn btn-primary">{{ index $t "submit" }}</button>
+      <span class="glossary-feedback-status" role="status" aria-live="polite"></span>
+    </div>
+  </form>
+</section>
+
+<style>
+  .glossary-feedback {
+    margin: 2.5rem 0 1.5rem;
+    padding: 1.5rem 1.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-inline-start: 4px solid #007bff;
+    border-radius: 8px;
+    background: rgba(0, 123, 255, 0.03);
+  }
+
+  .glossary-feedback-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .glossary-feedback-icon {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 50%;
+    background: rgba(0, 123, 255, 0.12);
+    color: #007bff;
+    font-size: 1.1rem;
+  }
+
+  .glossary-feedback-heading {
+    margin: 0 0 0.2rem;
+    font-size: 1.05rem;
+    font-weight: 700;
+  }
+
+  .glossary-feedback-intro {
+    margin: 0;
+    color: #6c757d;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .glossary-feedback-form .form-group {
+    margin-bottom: 1rem;
+  }
+
+  .glossary-feedback-form label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+  }
+
+  .glossary-feedback-form .form-control:focus {
+    border-color: #007bff;
+    box-shadow: 0 0 0 0.15rem rgba(0, 123, 255, 0.2);
+  }
+
+  .glossary-feedback-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 1.25rem;
+  }
+
+  @media (max-width: 576px) {
+    .glossary-feedback {
+      padding: 1.25rem;
+    }
+
+    .glossary-feedback-row {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .glossary-feedback-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+  }
+
+  .glossary-feedback-status {
+    font-size: 0.85rem;
+    color: #28a745;
+  }
+
+  .glossary-feedback-status.text-danger {
+    color: #dc3545 !important;
+  }
+
+  .glossary-feedback-hp {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  .dark .glossary-feedback {
+    background: rgba(0, 123, 255, 0.07);
+    border-color: rgb(68, 71, 90);
+  }
+
+  .dark .glossary-feedback-intro {
+    color: rgb(152, 166, 173);
+  }
+</style>
+
+<script>
+  window.GLOSSARY_FEEDBACK_I18N = {
+    sending: {{ index $t "sending" | jsonify | safeJS }},
+    thanks: {{ index $t "thanks" | jsonify | safeJS }},
+    error: {{ index $t "error" | jsonify | safeJS }}
+  };
+</script>
+<script src="{{ "js/glossary-feedback.js" | relURL }}" defer></script>

--- a/layouts/partials/glossary_feedback_form.html
+++ b/layouts/partials/glossary_feedback_form.html
@@ -89,57 +89,62 @@
 }}
 {{ $t := index $dictionary $lang }}
 
-<section class="glossary-feedback"{{ if eq $lang "arabic" }} dir="rtl"{{ end }}>
-  <div class="glossary-feedback-header">
+{{/* form collapsed by default so the form doesn't compete with the entry's content */}}
+<details class="glossary-feedback"{{ if eq $lang "arabic" }} dir="rtl"{{ end }}>
+  <summary class="glossary-feedback-header">
     <span class="glossary-feedback-icon" aria-hidden="true">&#9998;</span>
-    <div>
-      <h3 class="glossary-feedback-heading">{{ index $t "heading" }}</h3>
-      <p class="glossary-feedback-intro">{{ index $t "intro" }}</p>
-    </div>
+    <span class="glossary-feedback-heading">{{ index $t "heading" }}</span>
+    <span class="glossary-feedback-chevron" aria-hidden="true">&#9662;</span>
+  </summary>
+
+  <div class="glossary-feedback-body">
+    <p class="glossary-feedback-intro">{{ index $t "intro" }}</p>
+
+    {{/* data-* attributes carry page context into the submission payload;
+         read by static/js/glossary-feedback.js, */}}
+    <form id="glossary-feedback-form"
+          class="glossary-feedback-form"
+          data-term="{{ .Title }}"
+          data-url="{{ .Permalink }}"
+          data-language="{{ $lang }}">
+
+      <div class="glossary-feedback-row">
+        <div class="form-group glossary-feedback-type">
+          <label for="glossary-feedback-type">{{ index $t "type_label" }}</label>
+          <select id="glossary-feedback-type" name="feedback_type" class="form-control" required>
+            <option value="" disabled selected>{{ index $t "type_placeholder" }}</option>
+            <option value="correction">{{ index $t "type_correction" }}</option>
+            <option value="suggestion">{{ index $t "type_suggestion" }}</option>
+            <option value="other">{{ index $t "type_other" }}</option>
+          </select>
+        </div>
+
+        <div class="form-group glossary-feedback-email">
+          <label for="glossary-feedback-email">{{ index $t "email_label" }}</label>
+          <input type="email" id="glossary-feedback-email" name="email" class="form-control">
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="glossary-feedback-message">{{ index $t "message_label" }}</label>
+        <textarea id="glossary-feedback-message" name="message" class="form-control" rows="3"
+                  required placeholder="{{ index $t "message_placeholder" }}"></textarea>
+      </div>
+
+      {{/* Honeypot: hidden from sighted users and skipped by screen readers
+           via aria-hidden; most bots fill in every field regardless. */}}
+      <div class="glossary-feedback-hp" aria-hidden="true">
+        <label for="glossary-feedback-website">Website</label>
+        <input type="text" id="glossary-feedback-website" name="website" tabindex="-1" autocomplete="off">
+      </div>
+
+      <div class="glossary-feedback-actions">
+        <button type="submit" class="btn btn-primary">{{ index $t "submit" }}</button>
+        <span class="glossary-feedback-status" role="status" aria-live="polite"></span>
+      </div>
+    </form>
   </div>
-
-  <form id="glossary-feedback-form"
-        class="glossary-feedback-form"
-        data-term="{{ .Title }}"
-        data-url="{{ .Permalink }}"
-        data-language="{{ $lang }}">
-
-    <div class="glossary-feedback-row">
-      <div class="form-group glossary-feedback-type">
-        <label for="glossary-feedback-type">{{ index $t "type_label" }}</label>
-        <select id="glossary-feedback-type" name="feedback_type" class="form-control" required>
-          <option value="" disabled selected>{{ index $t "type_placeholder" }}</option>
-          <option value="correction">{{ index $t "type_correction" }}</option>
-          <option value="suggestion">{{ index $t "type_suggestion" }}</option>
-          <option value="other">{{ index $t "type_other" }}</option>
-        </select>
-      </div>
-
-      <div class="form-group glossary-feedback-email">
-        <label for="glossary-feedback-email">{{ index $t "email_label" }}</label>
-        <input type="email" id="glossary-feedback-email" name="email" class="form-control">
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label for="glossary-feedback-message">{{ index $t "message_label" }}</label>
-      <textarea id="glossary-feedback-message" name="message" class="form-control" rows="3"
-                required placeholder="{{ index $t "message_placeholder" }}"></textarea>
-    </div>
-
-    {{/* Honeypot: hidden from sighted users and skipped by screen readers
-         via aria-hidden; most bots fill in every field regardless. */}}
-    <div class="glossary-feedback-hp" aria-hidden="true">
-      <label for="glossary-feedback-website">Website</label>
-      <input type="text" id="glossary-feedback-website" name="website" tabindex="-1" autocomplete="off">
-    </div>
-
-    <div class="glossary-feedback-actions">
-      <button type="submit" class="btn btn-primary">{{ index $t "submit" }}</button>
-      <span class="glossary-feedback-status" role="status" aria-live="polite"></span>
-    </div>
-  </form>
-</section>
+</details>
 
 <style>
   .glossary-feedback {
@@ -155,9 +160,20 @@
 
   .glossary-feedback-header {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 0.85rem;
-    margin-bottom: 1.25rem;
+    /* <summary> renders the header row; strip its native disclosure
+       triangle so our own chevron is the only toggle affordance. */
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .glossary-feedback-header::-webkit-details-marker {
+    display: none;
+  }
+
+  .glossary-feedback-header::marker {
+    content: "";
   }
 
   .glossary-feedback-icon {
@@ -174,13 +190,30 @@
   }
 
   .glossary-feedback-heading {
-    margin: 0 0 0.2rem;
+    margin: 0;
     font-size: 1.05rem;
     font-weight: 700;
+    flex: 1 1 auto;
+  }
+
+  .glossary-feedback-chevron {
+    flex: none;
+    color: #6c757d;
+    font-size: 0.8rem;
+    transition: transform 0.2s ease;
+  }
+
+  /* Rotate the chevron to point up once the <details> is expanded. */
+  .glossary-feedback[open] .glossary-feedback-chevron {
+    transform: rotate(180deg);
+  }
+
+  .glossary-feedback-body {
+    margin-top: 1.25rem;
   }
 
   .glossary-feedback-intro {
-    margin: 0;
+    margin: 0 0 1rem;
     color: #6c757d;
     font-size: 0.9rem;
     line-height: 1.5;
@@ -191,9 +224,15 @@
   }
 
   .glossary-feedback-form label {
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     font-weight: 600;
     margin-bottom: 0.35rem;
+  }
+
+  /* Bootstrap's default .form-control font-size (1rem) reads oversized next
+     to this form's compact label/intro text — halved to match. */
+  .glossary-feedback-form .form-control {
+    font-size: 0.7rem;
   }
 
   .glossary-feedback-form .form-control:focus {
@@ -234,6 +273,9 @@
     color: #dc3545 !important;
   }
 
+  /* Off-screen positioning (not display:none) keeps the field in the
+     accessibility tree's "present but hidden" state — some bots skip
+     display:none fields outright but still auto-fill this kind of trap. */
   .glossary-feedback-hp {
     position: absolute;
     left: -9999px;

--- a/layouts/shortcodes/adopting_feedback_form.html
+++ b/layouts/shortcodes/adopting_feedback_form.html
@@ -12,7 +12,7 @@
   <div class="adopting-feedback-header">
     <span class="adopting-feedback-icon" aria-hidden="true">&#9998;</span>
     <div>
-      <h3 class="adopting-feedback-heading">FORRT Adopting Principled Education Feedback</h3>
+      <h3 class="adopting-feedback-heading">Adopting Principled Education Feedback</h3>
       <p class="adopting-feedback-intro">We’d love to hear from the community! Please share your experiences using these teaching tips. Your feedback helps us understand what works, what needs adapting, and for which students.</p>
     </div>
   </div>

--- a/layouts/shortcodes/adopting_feedback_form.html
+++ b/layouts/shortcodes/adopting_feedback_form.html
@@ -1,0 +1,191 @@
+{{/*
+  "Adopting Principled Education" feedback form.
+  Submits to the same Google Apps Script web app used by the glossary
+  feedback form (see .feedback-appscript/Code.js and
+  layouts/partials/glossary_feedback_form.html), which appends each
+  submission as a row to an "adopting_feedback" sheet.
+  Client logic: static/js/adopting-feedback.js.
+
+  Usage: {{< adopting_feedback_form >}}
+*/}}
+<section class="adopting-feedback" id="adopting-feedback-form-section">
+  <div class="adopting-feedback-header">
+    <span class="adopting-feedback-icon" aria-hidden="true">&#9998;</span>
+    <div>
+      <h3 class="adopting-feedback-heading">FORRT Adopting Principled Education Feedback</h3>
+      <p class="adopting-feedback-intro">We’d love to hear from the community! Please share your experiences using these teaching tips. Your feedback helps us understand what works, what needs adapting, and for which students.</p>
+    </div>
+  </div>
+  <form id="adopting-feedback-form" class="adopting-feedback-form">
+    <div class="form-group">
+      <label for="adopting-feedback-tips-used">1. Which tips have you used? <span class="adopting-feedback-optional">(Optional)</span></label>
+      <input type="text" id="adopting-feedback-tips-used" name="tips_used" class="form-control" placeholder="List the tips you tried or applied.">
+    </div>
+    <div class="form-group">
+      <label for="adopting-feedback-what-worked">2. What worked well, or what did you have to change? <span class="adopting-feedback-optional">(Optional)</span></label>
+      <textarea id="adopting-feedback-what-worked" name="what_worked" class="form-control" rows="3"></textarea>
+    </div>
+    <div class="form-group">
+      <label>3. What demographic of students did you use these tips for? <span class="adopting-feedback-optional">(Optional)</span></label>
+      <div class="adopting-feedback-checkboxes">
+        <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="bachelor"> Bachelor students</label>
+        <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="masters"> Master’s students</label>
+        <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="phd"> PhD students</label>
+        <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="other"> Other (please specify)</label>
+      </div>
+      <div id="adopting-feedback-demographics-other-field" class="adopting-feedback-other-field">
+        <input type="text" id="adopting-feedback-demographics-other" name="demographics_other" class="form-control" placeholder="Please specify">
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="adopting-feedback-additional-comments">4. Additional comments / feedback <span class="adopting-feedback-optional">(Optional)</span></label>
+      <textarea id="adopting-feedback-additional-comments" name="additional_comments" class="form-control" rows="3"></textarea>
+    </div>
+    <!-- Honeypot: hidden from sighted users and skipped by screen readers via
+         aria-hidden; most bots fill in every field regardless. -->
+    <div class="adopting-feedback-hp" aria-hidden="true">
+      <label for="adopting-feedback-website">Website</label>
+      <input type="text" id="adopting-feedback-website" name="website" tabindex="-1" autocomplete="off">
+    </div>
+    <div class="adopting-feedback-actions">
+      <button type="submit" class="btn btn-primary">Submit</button>
+      <span class="adopting-feedback-status" role="status" aria-live="polite"></span>
+    </div>
+  </form>
+  <div id="adopting-feedback-thanks" class="adopting-feedback-thanks" hidden>
+    <h3>Thank You!</h3>
+    <p>Thank you for taking the time to share your feedback. We really appreciate your insights, they help us understand what works, what needs adapting, and how to better support students.</p>
+  </div>
+</section>
+
+<style>
+  .adopting-feedback {
+    margin: 2rem 0;
+    padding: 1.5rem 1.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    /* Logical property for visual consistency with the (RTL-aware) glossary
+       feedback form, even though this page itself is English-only. */
+    border-inline-start: 4px solid #007bff;
+    border-radius: 8px;
+    background: rgba(0, 123, 255, 0.03);
+  }
+
+  .adopting-feedback-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .adopting-feedback-icon {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 50%;
+    background: rgba(0, 123, 255, 0.12);
+    color: #007bff;
+    font-size: 1.1rem;
+  }
+
+  .adopting-feedback-heading {
+    margin: 0 0 0.2rem;
+    font-size: 1.05rem;
+    font-weight: 700;
+  }
+
+  .adopting-feedback-intro {
+    margin: 0;
+    color: #6c757d;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .adopting-feedback-form .form-group {
+    margin-bottom: 1.1rem;
+  }
+
+  .adopting-feedback-form label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+  }
+
+  .adopting-feedback-optional {
+    font-weight: 400;
+    color: #6c757d;
+    font-size: 0.8rem;
+  }
+
+  .adopting-feedback-form .form-control:focus {
+    border-color: #007bff;
+    box-shadow: 0 0 0 0.15rem rgba(0, 123, 255, 0.2);
+  }
+
+  .adopting-feedback-checkboxes {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .adopting-feedback-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 400;
+    font-size: 0.95rem;
+  }
+
+  .adopting-feedback-checkbox input {
+    width: auto;
+    margin: 0;
+  }
+
+  .adopting-feedback-other-field {
+    margin-top: 0.5rem;
+    max-width: 320px;
+  }
+
+  .adopting-feedback-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+  }
+
+  .adopting-feedback-status {
+    font-size: 0.85rem;
+    color: #28a745;
+  }
+
+  .adopting-feedback-status.text-danger {
+    color: #dc3545 !important;
+  }
+
+  .adopting-feedback-hp {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  .adopting-feedback-thanks {
+    text-align: center;
+    padding: 1rem 0;
+  }
+
+  .dark .adopting-feedback {
+    background: rgba(0, 123, 255, 0.07);
+    border-color: rgb(68, 71, 90);
+  }
+
+  .dark .adopting-feedback-intro {
+    color: rgb(152, 166, 173);
+  }
+</style>
+
+<script src="/js/adopting-feedback.js" defer></script>

--- a/layouts/shortcodes/adopting_feedback_form.html
+++ b/layouts/shortcodes/adopting_feedback_form.html
@@ -18,15 +18,15 @@
   </div>
   <form id="adopting-feedback-form" class="adopting-feedback-form">
     <div class="form-group">
-      <label for="adopting-feedback-tips-used">1. Which tips have you used? <span class="adopting-feedback-optional">(Optional)</span></label>
-      <input type="text" id="adopting-feedback-tips-used" name="tips_used" class="form-control" placeholder="List the tips you tried or applied.">
+      <label for="adopting-feedback-tips-used">1. Which tips have you used?</label>
+      <input type="text" id="adopting-feedback-tips-used" name="tips_used" class="form-control" placeholder="List the tips you tried or applied." required>
     </div>
     <div class="form-group">
-      <label for="adopting-feedback-what-worked">2. What worked well, or what did you have to change? <span class="adopting-feedback-optional">(Optional)</span></label>
-      <textarea id="adopting-feedback-what-worked" name="what_worked" class="form-control" rows="3"></textarea>
+      <label for="adopting-feedback-what-worked">2. What worked well, or what did you have to change?</label>
+      <textarea id="adopting-feedback-what-worked" name="what_worked" class="form-control" rows="3" required></textarea>
     </div>
     <div class="form-group">
-      <label>3. What demographic of students did you use these tips for? <span class="adopting-feedback-optional">(Optional)</span></label>
+      <label>3. What demographic of students did you use these tips for?</label>
       <div class="adopting-feedback-checkboxes">
         <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="bachelor"> Bachelor students</label>
         <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="masters"> Master’s students</label>
@@ -117,6 +117,12 @@
     font-weight: 400;
     color: #6c757d;
     font-size: 0.8rem;
+  }
+
+  /* Bootstrap's default .form-control font-size (1rem) reads oversized next
+     to this form's compact label/intro text — halved to match. */
+  .adopting-feedback-form .form-control {
+    font-size: 0.7rem;
   }
 
   .adopting-feedback-form .form-control:focus {

--- a/layouts/shortcodes/adopting_feedback_form.html
+++ b/layouts/shortcodes/adopting_feedback_form.html
@@ -25,18 +25,18 @@
       <label for="adopting-feedback-what-worked">2. What worked well, or what did you have to change?</label>
       <textarea id="adopting-feedback-what-worked" name="what_worked" class="form-control" rows="3" required></textarea>
     </div>
-    <div class="form-group">
-      <label>3. What demographic of students did you use these tips for?</label>
+    <fieldset class="form-group">
+      <legend>3. What demographic of students did you use these tips for?</legend>
       <div class="adopting-feedback-checkboxes">
         <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="bachelor"> Bachelor students</label>
         <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="masters"> Master’s students</label>
         <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="phd"> PhD students</label>
         <label class="adopting-feedback-checkbox"><input type="checkbox" name="demographics" value="other"> Other (please specify)</label>
       </div>
-      <div id="adopting-feedback-demographics-other-field" class="adopting-feedback-other-field">
+      <div id="adopting-feedback-demographics-other-field" class="adopting-feedback-other-field" style="display:none">
         <input type="text" id="adopting-feedback-demographics-other" name="demographics_other" class="form-control" placeholder="Please specify">
       </div>
-    </div>
+    </fieldset>
     <div class="form-group">
       <label for="adopting-feedback-additional-comments">4. Additional comments / feedback <span class="adopting-feedback-optional">(Optional)</span></label>
       <textarea id="adopting-feedback-additional-comments" name="additional_comments" class="form-control" rows="3"></textarea>

--- a/static/js/adopting-feedback.js
+++ b/static/js/adopting-feedback.js
@@ -1,0 +1,100 @@
+/**
+ * "Adopting Principled Education" feedback form.
+ * Submits to a Google Apps Script web app (see .feedback-appscript/Code.js),
+ * which appends each submission as a row to an "adopting_feedback" sheet.
+ * Override window.FORRT_FEEDBACK_URL before this script loads to point elsewhere.
+ */
+(function () {
+  'use strict';
+
+  var FEEDBACK_URL = (typeof window.FORRT_FEEDBACK_URL !== 'undefined')
+    ? window.FORRT_FEEDBACK_URL
+    : 'https://script.google.com/macros/s/AKfycbwMOWeJSQRrLiZFUN18vbB8pW-dqdPZE9FtQXjYh5J33DRazccGr7MTNmSbV6lG2QQyXQ/exec';
+
+  /** Wires up the form. Guards on the element existing so this script can be
+   *  safely re-included or reloaded without throwing if the form isn't present. */
+  function init() {
+    var form = document.getElementById('adopting-feedback-form');
+    if (!form) return;
+
+    var statusEl = form.querySelector('.adopting-feedback-status');
+    var submitBtn = form.querySelector('button[type="submit"]');
+    var thanksEl = document.getElementById('adopting-feedback-thanks');
+
+    // Reveal the "please specify" field only while the "Other" checkbox is ticked.
+    var otherCheckbox = form.querySelector('input[name="demographics"][value="other"]');
+    var otherField = document.getElementById('adopting-feedback-demographics-other-field');
+    if (otherCheckbox && otherField) {
+      var toggleOther = function () {
+        otherField.style.display = otherCheckbox.checked ? '' : 'none';
+      };
+      otherCheckbox.addEventListener('change', toggleOther);
+      toggleOther();
+    }
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+
+      // Honeypot: left blank by humans (it's hidden off-screen), filled in by
+      // most bots that blindly populate every field. Silently drop those.
+      if (form.website && form.website.value) return;
+
+      // querySelectorAll returns a static NodeList, not an Array, so it needs
+      // slice.call before .map is available.
+      var demographics = Array.prototype.slice
+        .call(form.querySelectorAll('input[name="demographics"]:checked'))
+        .map(function (el) { return el.value; });
+
+      submitBtn.disabled = true;
+      statusEl.classList.remove('text-danger');
+      statusEl.textContent = 'Sending…';
+
+      // Sent as text/plain so the request stays a CORS "simple request" (no
+      // preflight, which the Apps Script endpoint can't answer). no-cors
+      // means we never see the real response, so we treat network success
+      // as submission success — same approach used for glossary feedback.
+      fetch(FEEDBACK_URL, {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify({
+          type: 'adopting_feedback',
+          // Every field on this form is optional, so all values default to
+          // '' rather than being required before submission.
+          tips_used: (form.tips_used.value || '').trim(),
+          what_worked: (form.what_worked.value || '').trim(),
+          demographics: demographics,
+          demographics_other: (form.demographics_other.value || '').trim(),
+          additional_comments: (form.additional_comments.value || '').trim(),
+          url: window.location.href,
+          ts: Date.now(),
+        }),
+        keepalive: true,
+      }).then(function () {
+        submitBtn.disabled = false;
+        form.reset();
+        // Prefer swapping in the dedicated thank-you panel; fall back to an
+        // inline status message if the markup doesn't include one.
+        if (thanksEl) {
+          form.hidden = true;
+          thanksEl.hidden = false;
+        } else {
+          statusEl.textContent = 'Thank you — your feedback has been recorded.';
+        }
+      }).catch(function () {
+        statusEl.classList.add('text-danger');
+        statusEl.textContent = 'Something went wrong. Please try again later.';
+        submitBtn.disabled = false;
+      });
+    });
+  }
+
+  // The script tag uses `defer`, so the DOM is normally already parsed by the
+  // time this runs — but the readyState check keeps init() safe if the script
+  // is ever loaded without `defer` or injected after page load.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/js/adopting-feedback.js
+++ b/static/js/adopting-feedback.js
@@ -32,6 +32,23 @@
       toggleOther();
     }
 
+    // Question 3 is a checkbox group: HTML's `required` can only demand one
+    // specific checkbox be checked, not "at least one of the group". The
+    // standard workaround is to keep every checkbox `required` while none
+    // are checked (so native validation blocks submit and focuses the
+    // group), then drop `required` from all of them the moment any one is
+    // checked (so the still-unchecked siblings don't also block submit).
+    var demographicCheckboxes = Array.prototype.slice
+      .call(form.querySelectorAll('input[name="demographics"]'));
+    var updateDemographicsRequired = function () {
+      var anyChecked = demographicCheckboxes.some(function (el) { return el.checked; });
+      demographicCheckboxes.forEach(function (el) { el.required = !anyChecked; });
+    };
+    demographicCheckboxes.forEach(function (el) {
+      el.addEventListener('change', updateDemographicsRequired);
+    });
+    updateDemographicsRequired();
+
     form.addEventListener('submit', function (e) {
       e.preventDefault();
 
@@ -44,6 +61,11 @@
       var demographics = Array.prototype.slice
         .call(form.querySelectorAll('input[name="demographics"]:checked'))
         .map(function (el) { return el.value; });
+
+      var tipsUsed = (form.tips_used.value || '').trim();
+      var whatWorked = (form.what_worked.value || '').trim();
+      var demographicsOther = (form.demographics_other.value || '').trim();
+      var additionalComments = (form.additional_comments.value || '').trim();
 
       submitBtn.disabled = true;
       statusEl.classList.remove('text-danger');
@@ -59,13 +81,11 @@
         headers: { 'Content-Type': 'text/plain;charset=utf-8' },
         body: JSON.stringify({
           type: 'adopting_feedback',
-          // Every field on this form is optional, so all values default to
-          // '' rather than being required before submission.
-          tips_used: (form.tips_used.value || '').trim(),
-          what_worked: (form.what_worked.value || '').trim(),
+          tips_used: tipsUsed,
+          what_worked: whatWorked,
           demographics: demographics,
-          demographics_other: (form.demographics_other.value || '').trim(),
-          additional_comments: (form.additional_comments.value || '').trim(),
+          demographics_other: demographicsOther,
+          additional_comments: additionalComments,
           url: window.location.href,
           ts: Date.now(),
         }),
@@ -73,6 +93,10 @@
       }).then(function () {
         submitBtn.disabled = false;
         form.reset();
+        // form.reset() doesn't fire 'change' on the checkboxes it clears, so
+        // the required-toggle above would otherwise be left stale (still
+        // "not required" from the checked box that just got submitted).
+        updateDemographicsRequired();
         // Prefer swapping in the dedicated thank-you panel; fall back to an
         // inline status message if the markup doesn't include one.
         if (thanksEl) {

--- a/static/js/adopting-feedback.js
+++ b/static/js/adopting-feedback.js
@@ -9,7 +9,7 @@
 
   var FEEDBACK_URL = (typeof window.FORRT_FEEDBACK_URL !== 'undefined')
     ? window.FORRT_FEEDBACK_URL
-    : 'https://script.google.com/macros/s/AKfycbwMOWeJSQRrLiZFUN18vbB8pW-dqdPZE9FtQXjYh5J33DRazccGr7MTNmSbV6lG2QQyXQ/exec';
+    : 'https://script.google.com/macros/s/AKfycbz0fGz3iLkkUOuO_r4o8_f-oHzgBzFVbBALJsy92GFijddYCTZ_Zav4kin6hVDMN6O-/exec';
 
   /** Wires up the form. Guards on the element existing so this script can be
    *  safely re-included or reloaded without throwing if the form isn't present. */

--- a/static/js/glossary-feedback.js
+++ b/static/js/glossary-feedback.js
@@ -1,9 +1,8 @@
 /**
  * Glossary entry feedback/suggestion form.
- * Submits to a Google Apps Script web app deployed from the same project as
- * the JUST-OS chat feedback (see .feedback-appscript/Code.js), which appends
- * each submission as a row to a "glossary_feedback" sheet in the "Forrt-feedbacks"
- * spreadsheet.
+ * Submits to a Google Apps Script web app (see .feedback-appscript/Code.js),
+ * which appends each submission as a row to a "glossary_feedback" sheet in
+ * the "Forrt-feedbacks" spreadsheet.
  * Override window.FORRT_FEEDBACK_URL before this script loads to point elsewhere.
  */
 (function () {
@@ -13,10 +12,14 @@
     ? window.FORRT_FEEDBACK_URL
     : 'https://script.google.com/macros/s/AKfycbwMOWeJSQRrLiZFUN18vbB8pW-dqdPZE9FtQXjYh5J33DRazccGr7MTNmSbV6lG2QQyXQ/exec';
 
+  /** Wires up the form. Guards on the element existing so this script can be
+   *  safely re-included or reloaded without throwing if the form isn't present. */
   function init() {
     var form = document.getElementById('glossary-feedback-form');
     if (!form) return;
 
+    // Populated per-page by the glossary_feedback_form partial (translated
+    // strings); the literal fallbacks below cover the case where it's missing.
     var i18n = window.GLOSSARY_FEEDBACK_I18N || {};
     var statusEl = form.querySelector('.glossary-feedback-status');
     var submitBtn = form.querySelector('button[type="submit"]');
@@ -28,6 +31,8 @@
       // most bots that blindly populate every field. Silently drop those.
       if (form.website && form.website.value) return;
 
+      // The textarea has `required`, but that only checks for non-empty input —
+      // whitespace-only text passes native validation, so re-check after trim.
       var message = form.message.value.trim();
       if (!message) {
         form.message.focus();
@@ -67,6 +72,9 @@
     });
   }
 
+  // The script tag uses `defer`, so the DOM is normally already parsed by the
+  // time this runs — but the readyState check keeps init() safe if the script
+  // is ever loaded without `defer` or injected after page load.
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);
   } else {

--- a/static/js/glossary-feedback.js
+++ b/static/js/glossary-feedback.js
@@ -1,0 +1,75 @@
+/**
+ * Glossary entry feedback/suggestion form.
+ * Submits to a Google Apps Script web app deployed from the same project as
+ * the JUST-OS chat feedback (see .feedback-appscript/Code.js), which appends
+ * each submission as a row to a "glossary_feedback" sheet in the "Forrt-feedbacks"
+ * spreadsheet.
+ * Override window.FORRT_FEEDBACK_URL before this script loads to point elsewhere.
+ */
+(function () {
+  'use strict';
+
+  var FEEDBACK_URL = (typeof window.FORRT_FEEDBACK_URL !== 'undefined')
+    ? window.FORRT_FEEDBACK_URL
+    : 'https://script.google.com/macros/s/AKfycbwMOWeJSQRrLiZFUN18vbB8pW-dqdPZE9FtQXjYh5J33DRazccGr7MTNmSbV6lG2QQyXQ/exec';
+
+  function init() {
+    var form = document.getElementById('glossary-feedback-form');
+    if (!form) return;
+
+    var i18n = window.GLOSSARY_FEEDBACK_I18N || {};
+    var statusEl = form.querySelector('.glossary-feedback-status');
+    var submitBtn = form.querySelector('button[type="submit"]');
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+
+      // Honeypot: left blank by humans (it's hidden off-screen), filled in by
+      // most bots that blindly populate every field. Silently drop those.
+      if (form.website && form.website.value) return;
+
+      var message = form.message.value.trim();
+      if (!message) {
+        form.message.focus();
+        return;
+      }
+
+      submitBtn.disabled = true;
+      statusEl.classList.remove('text-danger');
+      statusEl.textContent = i18n.sending || 'Sending…';
+
+      // Sent as text/plain so the request stays a CORS "simple request" (no
+      // preflight, which the Apps Script endpoint can't answer).
+      fetch(FEEDBACK_URL, {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify({
+          type: 'glossary_feedback',
+          term: form.dataset.term || '',
+          url: form.dataset.url || '',
+          language: form.dataset.language || '',
+          feedback_type: form.feedback_type.value,
+          message: message,
+          email: form.email.value.trim(),
+          ts: Date.now(),
+        }),
+        keepalive: true,
+      }).then(function () {
+        statusEl.textContent = i18n.thanks || 'Thank you — your feedback has been recorded.';
+        form.reset();
+        submitBtn.disabled = false;
+      }).catch(function () {
+        statusEl.classList.add('text-danger');
+        statusEl.textContent = i18n.error || 'Something went wrong. Please try again later.';
+        submitBtn.disabled = false;
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/js/glossary-feedback.js
+++ b/static/js/glossary-feedback.js
@@ -10,7 +10,7 @@
 
   var FEEDBACK_URL = (typeof window.FORRT_FEEDBACK_URL !== 'undefined')
     ? window.FORRT_FEEDBACK_URL
-    : 'https://script.google.com/macros/s/AKfycbwMOWeJSQRrLiZFUN18vbB8pW-dqdPZE9FtQXjYh5J33DRazccGr7MTNmSbV6lG2QQyXQ/exec';
+    : 'https://script.google.com/macros/s/AKfycbz0fGz3iLkkUOuO_r4o8_f-oHzgBzFVbBALJsy92GFijddYCTZ_Zav4kin6hVDMN6O-/exec';
 
   /** Wires up the form. Guards on the element existing so this script can be
    *  safely re-included or reloaded without throwing if the form isn't present. */

--- a/static/js/just-os-chat.js
+++ b/static/js/just-os-chat.js
@@ -860,6 +860,7 @@
       mode: 'no-cors',
       headers: { 'Content-Type': 'text/plain;charset=utf-8' },
       body: JSON.stringify({
+        type:     'chat',
         turn_id:  turnId,
         rho_exp:  rho_exp,
         signals:  signals || {},


### PR DESCRIPTION
## Description
<!-- Brief summary of the change -->

Adds two native feedback forms,  on individual glossary term pages and the "Adopting Principled Education" page,  that submit directly to a Google Sheet via a shared Google Apps Script backend, no third-party form embed required.

### Glossary entry pages

New "Suggest an improvement" form (correction / suggestion / other, message, optional email), translated into all 5 glossary languages, RTL-aware for Arabic.
Submits to a glossary_feedback sheet tab

### Adopting Principled Education page

APE feedback form (tips used, what worked, student demographics, comments) matching the page's existing "share your experience" call-to-action, replacing a dead/empty Google Form link.
Submits to a separate adopting_feedback sheet tab in the same spreadsheet.

**Appscript**
.feedback-appscript/Code.js now dispatches on a type field to route chat / glossary / adopting submissions to their own created sheet tabs in one shared Apps Script deployment.

Fixes #743 

## Type of Change
- [x] Content/documentation update
- [x] New feature

## Testing
- [x] Tested locally
- [x] Previewed on [staging.forrt.org](https://staging.forrt.org/)

## Checklist
- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes
<!-- Optional: screenshots or additional context -->
