### PR TITLE
Fix stale curated-resource pages surviving data refreshes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,6 +44,13 @@ jobs:
       # =======================
       # Data Artifact Retrieval
       # =======================
+      # The repository contains a generated seed copy of curated resources.
+      # Remove it before overlaying the artifact so rows removed from the
+      # source sheet cannot survive in the deployed site.
+      - name: Clear generated curated resources
+        run: |
+          find content/curated_resources -maxdepth 1 -type f ! -name '_index.md' -delete
+
       - name: Try to download data artifact
         id: download-artifact
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295

--- a/content/resources/resource.py
+++ b/content/resources/resource.py
@@ -87,6 +87,12 @@ def convert_row_to_file(df, fpath):
     If there are duplicates, an index is appended to the filename.
     """
     
+    # Replace the generated collection rather than leaving files for rows that
+    # have been removed from the source sheet.
+    for path in fpath.iterdir():
+        if path.is_file() and path.name != '_index.md':
+            path.unlink()
+
     # Track filenames to handle duplicates
     filename_counts = {}
 


### PR DESCRIPTION
## What Problem This Solves

Retired curated-resource rows could remain publicly accessible under `/curated_resources/`. The generator rewrote current rows without deleting files removed from the source sheet, and the deployment workflow overlaid generated artifacts on the checkout without clearing the generated directory.

## Why This Change Was Made

- Remove generated resource files before regenerating the collection, while preserving `_index.md`.
- Clear the generated resource directory before the data artifact is unpacked during deployment.

This makes the generated collection a replacement of the source data rather than an additive merge.

## User Impact

Pages for resources removed from the source sheet will no longer be rebuilt or remain in the deployed site. Current curated-resource URLs continue to be generated unchanged.

## Evidence

- Focused generator replacement test passed: stale file removed and `_index.md` preserved.
- Focused deployment cleanup test passed.
- `deploy.yaml` parses as valid YAML.
- Python source compiles successfully.

Fixes forrtproject/forrtproject.github.io#873
