### PR TITLE
Improve glossary redirect fallback and term-set URLs

### DIFF
--- a/content/glossary/english/_index.md
+++ b/content/glossary/english/_index.md
@@ -34,13 +34,11 @@ Accompanying this cultural shift towards increased transparency and rigour has b
 
 In order to reduce barriers to entry and understanding, we present a Glossary of terms relating to open scholarship. We aim that the glossary will help clarify terminologies, including where terms are used differently/interchangeably or where terms are less known in some fields or among students. We also hope that this glossary will be a welcome resource for those new to these concepts, and that it helps grow their confidence in navigating discussions of open scholarship. We also hope that this glossary aids in mentoring and teaching, and allows newcomers and experts to communicate efficiently. 
 
-{{% alert note %}}
+If you use this glossary in any form, please cite the associated paper:
 
-If you use this glossary in any form, please cite the associated paper: Parsons, S., Azevedo, F., Elsherif, M. M., Guay, S., Shahim, O. N., Govaart, G. H., ... & Aczel, B. (2022). A Community-Sourced Glossary of Open Scholarship Terms. *Nature human behaviour, 6*(3), 312-318. [https://doi.org/10.1038/s41562-021-01269-4](https://doi.org/10.1038/s41562-021-01269-4)
+{{< glossary-citation >}}
 
 👀 [The [Open Access link](https://rdcu.be/cHsqM) to the copy-edited version at the publisher's website, and here's the [postprint](https://doi.org/10.31222/osf.io/kdqcw) which is the same as the published version.] ⬅️
-
-{{% /alert %}}
 
 The list of terms we have drafted and reviewed can be found on the left if you are viewing this page on a computer screen or bigger, otherwise they can be found at the bottom of the page. If you hover a word, you will be able to read the full description of the term. To know more about a term, including references, simply click on it and it will bring you to the term page. 
 

--- a/content/glossary/english/_index.md
+++ b/content/glossary/english/_index.md
@@ -36,7 +36,9 @@ In order to reduce barriers to entry and understanding, we present a Glossary of
 
 If you use this glossary in any form, please cite the associated paper:
 
-{{< glossary-citation >}}
+{{< citation-card >}}
+Parsons, S., Azevedo, F., Elsherif, M. M., Guay, S., Shahim, O. N., Govaart, G. H., … & Aczel, B. (2022). A Community-Sourced Glossary of Open Scholarship Terms. *Nature Human Behaviour, 6*(3), 312–318. [https://doi.org/10.1038/s41562-021-01269-4](https://doi.org/10.1038/s41562-021-01269-4)
+{{< /citation-card >}}
 
 👀 [The [Open Access link](https://rdcu.be/cHsqM) to the copy-edited version at the publisher's website, and here's the [postprint](https://doi.org/10.31222/osf.io/kdqcw) which is the same as the published version.] ⬅️
 

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="{{ site.Language.Locale }}">
+  <head>
+    <title>{{ .Permalink }}</title>
+    <link rel="canonical" href="{{ .Permalink }}">
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+  </head>
+  <body>
+    <p>This page has moved. <a href="{{ .Permalink }}">Continue to the new location</a>.</p>
+  </body>
+</html>

--- a/layouts/partials/structured-data/glossary-term.html
+++ b/layouts/partials/structured-data/glossary-term.html
@@ -7,12 +7,13 @@
   {{- $desc := .Params.definition | plainify | replaceRE `\*+` "" | truncate 300 "…" -}}
   {{/* Defense-in-depth: stop a literal </script from terminating the tag. */}}
   {{- $desc = replaceRE "(?i)</script" "<\\/script" $desc -}}
+  {{- $languageName := .Params.language | default "english" -}}
   {{- $langMap := dict "arabic" "ar" "chinese" "zh" "english" "en" "german" "de" "turkish" "tr" -}}
-  {{- $lang := index $langMap (.Params.language | default "english") | default "en" -}}
+  {{- $lang := index $langMap $languageName | default "en" -}}
   {{- $set := dict
       "@type" "DefinedTermSet"
       "name" "FORRT Glossary of Open and Reproducible Science"
-      "url" (absURL "glossary/")
+      "url" (absURL (printf "glossary/%s/" $languageName))
       "inLanguage" $lang -}}
   {{- $term := dict
       "@context" "https://schema.org"

--- a/layouts/shortcodes/citation-card.html
+++ b/layouts/shortcodes/citation-card.html
@@ -7,13 +7,10 @@
   <link rel="stylesheet" href="{{ "css/cite_us.css" | relURL }}">
 {{ end }}
 
-<div class="cite-us-section glossary-citation">
+<div class="cite-us-section citation-card">
   <div class="cite-us-item">
-    <div class="cite-us-text">
-      Parsons, S., Azevedo, F., Elsherif, M. M., Guay, S., Shahim, O. N., Govaart, G. H., … &amp; Aczel, B. (2022). A Community-Sourced Glossary of Open Scholarship Terms. <em>Nature Human Behaviour, 6</em>(3), 312–318.
-      <a href="https://doi.org/10.1038/s41562-021-01269-4" target="_blank" rel="noopener" class="doi-link">https://doi.org/10.1038/s41562-021-01269-4</a>
-    </div>
-    <button type="button" class="copy-button" aria-label="Copy glossary citation" onclick="copyGlossaryCitation(this)">
+    <div class="cite-us-text">{{ .Inner | markdownify }}</div>
+    <button type="button" class="copy-button" aria-label="Copy citation" onclick="copyCitationCard(this)">
       <svg class="copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
       </svg>
@@ -23,7 +20,7 @@
 </div>
 
 <script>
-  async function copyGlossaryCitation(button) {
+  async function copyCitationCard(button) {
     const citation = button.previousElementSibling.innerText.trim();
     const originalContent = button.innerHTML;
 

--- a/layouts/shortcodes/glossary-citation.html
+++ b/layouts/shortcodes/glossary-citation.html
@@ -1,0 +1,48 @@
+{{ $css := resources.Get "css/cite_us.css" }}
+{{ if $css }}
+  {{ $style := $css | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+{{ else }}
+  {{ warnf "CSS not found: css/cite_us.css. Using static version" }}
+  <link rel="stylesheet" href="{{ "css/cite_us.css" | relURL }}">
+{{ end }}
+
+<div class="cite-us-section glossary-citation">
+  <div class="cite-us-item">
+    <div class="cite-us-text">
+      Parsons, S., Azevedo, F., Elsherif, M. M., Guay, S., Shahim, O. N., Govaart, G. H., … &amp; Aczel, B. (2022). A Community-Sourced Glossary of Open Scholarship Terms. <em>Nature Human Behaviour, 6</em>(3), 312–318.
+      <a href="https://doi.org/10.1038/s41562-021-01269-4" target="_blank" rel="noopener" class="doi-link">https://doi.org/10.1038/s41562-021-01269-4</a>
+    </div>
+    <button type="button" class="copy-button" aria-label="Copy glossary citation" onclick="copyGlossaryCitation(this)">
+      <svg class="copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+      </svg>
+      Copy
+    </button>
+  </div>
+</div>
+
+<script>
+  async function copyGlossaryCitation(button) {
+    const citation = button.previousElementSibling.innerText.trim();
+    const originalContent = button.innerHTML;
+
+    try {
+      await navigator.clipboard.writeText(citation);
+    } catch (err) {
+      const textarea = document.createElement('textarea');
+      textarea.value = citation;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+
+    button.innerHTML = '<svg class="copy-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>Copied!';
+    button.classList.add('copied');
+    setTimeout(() => {
+      button.innerHTML = originalContent;
+      button.classList.remove('copied');
+    }, 2000);
+  }
+</script>


### PR DESCRIPTION
## Description

Keeps English as the default glossary instead of introducing a separate language-selection page.

- overrides Hugo’s generated alias document to retain the instant meta-refresh while adding an ordinary fallback link
- points each glossary term’s `DefinedTermSet.url` at its language-specific glossary root
- presents the English glossary paper with a reusable citation-card shortcode, using the same styling as the Cite us page and including a copy action
- changes shared generation templates only for generated glossary output; generated glossary term files remain untouched

This deliberately resolves #866 without adding a new `/glossary/` hub. Google treats an instant meta-refresh as a permanent redirect when a server-side redirect is unavailable, and the existing `x-default` already identifies English as the fallback.

## Type of Change

- [ ] Content/documentation update
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change

## Testing

- [x] Tested locally
- [ ] Previewed on [staging.forrt.org](https://staging.forrt.org/)
- [ ] Not tested yet

Built the full production site with Hugo 0.164.0 and verified:

- `/glossary/index.html` contains the instant refresh, canonical, and fallback anchor to `/glossary/english/`
- English and German sample terms emit language-specific `DefinedTermSet.url` values
- the English glossary citation card renders locally with its DOI and Copy button

## Checklist

- [x] Self-reviewed my changes
- [x] Verified links and formatting are correct
- [x] No new warnings or errors

## Notes

The build reports two pre-existing Hugo deprecation warnings unrelated to this change.